### PR TITLE
feat: configurable inflation profiles + README inflation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,28 @@ Pour un guide complet, voir :
 - **📈 Simulateur long terme**
   Projections multi‑scénarios, croissance composée, analyse de sensibilité.
 
+- **📊 Inflation paramétrable**
+  Profils d'inflation prédéfinis (IPC standard, urbain locataire, projet immo, m² de ville) ou taux personnalisé. Voir la section [Inflation](#-inflation-paramétrable) ci-dessous.
+
 👉 Détails : **[docs/INTERFACE_WEB.md](./docs/INTERFACE_WEB.md)**
+
+---
+
+## 📊 Inflation Paramétrable
+
+Le simulateur long terme propose quatre profils d'inflation prédéfinis, plus une option personnalisée :
+
+| Profil | Taux | Plage indicative | Cas d'usage |
+|---|---|---|---|
+| **Standard IPC** (défaut) | 2,0 %/an | 1,7–2,0 % | Neutraliser l'inflation officielle sur les dépenses courantes |
+| **Urbain locataire** | 2,3 %/an | 2,2–2,5 % | Locataire en ville avec un loyer significatif |
+| **Vie urbaine + projet immo** | 3,0 %/an | 2,7–3,2 % | Utilisateur visant l'accession à la propriété en ville |
+| **Indexé m² de ville** | 4,0 %/an | 3,5–5,0 % | Suivi du patrimoine au prix du m² immobilier urbain |
+| **Personnalisé** | libre | — | Saisir manuellement tout autre taux |
+
+Les taux sont basés sur les séries longues [INSEE IPC](https://www.insee.fr/fr/statistiques/4268033), les indices de référence des loyers ([IRL — ANIL](https://www.anil.org/outils/indices-et-plafonds/tableau-de-lirl/)) et les travaux [IGEDD/Friggit](https://www.cgedd.fr/prix-immobilier-friggit.pdf) sur l'évolution des prix immobiliers.
+
+> **Comment ça marche ?** Dans le simulateur, remplace le simple champ *Inflation annuelle (%)* par un sélecteur de profil. Le taux correspondant est appliqué automatiquement à toutes les projections et apparaît dans le rapport PDF exporté.
 
 ---
 

--- a/finance_tracker/services/simulation_pdf_service.py
+++ b/finance_tracker/services/simulation_pdf_service.py
@@ -145,6 +145,7 @@ class SimulationPDFService:
             config_years=config_params.get("years", "N/A"),
             config_period=config_params.get("period", "N/A"),
             config_inflation=f"{config_params.get('inflation_pct', 0):.1f}%",
+            config_inflation_profile=config_params.get("inflation_profile", ""),
             config_income_start=f"{config_params.get('income_start', 0):,.0f}".replace(",", " "),
             config_income_growth=f"{config_params.get('income_growth_pct', 0):.1f}%",
             config_living_costs=f"{config_params.get('annual_living_costs', 0):,.0f}".replace(",", " "),

--- a/finance_tracker/web/app.py
+++ b/finance_tracker/web/app.py
@@ -125,6 +125,10 @@ st.sidebar.markdown("---")
 pages = build_pages()
 labels = [p.label for p in pages]
 selected = st.sidebar.radio("Navigation", labels)
+st.sidebar.link_button(
+    "📖 Documentation (README)",
+    f"{GITHUB_BASE_URL}/README.md",
+    )
 st.sidebar.markdown("---")
 
 # donation button

--- a/finance_tracker/web/views/simulation.py
+++ b/finance_tracker/web/views/simulation.py
@@ -203,6 +203,58 @@ _METRIC_LABELS: dict[str, str] = {
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# INFLATION PROFILES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_INFLATION_PROFILES: list[dict] = [
+    {
+        "key": "standard_cpi",
+        "label": "📊 Standard IPC — 2,0 %/an",
+        "rate": 2.0,
+        "description": (
+            "Utilise l'inflation officielle moyenne (IPC France). "
+            "Adapté pour neutraliser l'inflation sur les dépenses courantes "
+            "(alimentation, transports, services…)."
+        ),
+    },
+    {
+        "key": "urban_tenant",
+        "label": "🏙️ Urbain locataire — 2,3 %/an",
+        "rate": 2.3,
+        "description": (
+            "Recommandé si tu es locataire en ville et que ton loyer pèse lourd "
+            "dans ton budget. Combine inflation conso (70%) et logement (30%)."
+        ),
+    },
+    {
+        "key": "urban_owner",
+        "label": "🏠 Vie urbaine + projet immo — 3,0 %/an",
+        "rate": 3.0,
+        "description": (
+            "À choisir si ton objectif inclut l'accession à la propriété en ville. "
+            "Combine inflation conso, loyers et prix d'achat des logements."
+        ),
+    },
+    {
+        "key": "urban_sqm",
+        "label": "📐 Indexé m² de ville — 4,0 %/an",
+        "rate": 4.0,
+        "description": (
+            "Profil patrimonial avancé : ton patrimoine financier suit le prix "
+            "du m² immobilier en grande ville (hausse historique ~4–5 %/an)."
+        ),
+    },
+    {
+        "key": "custom",
+        "label": "✏️ Personnalisé",
+        "rate": None,
+        "description": "Saisir manuellement le taux d'inflation annuel souhaité.",
+    },
+]
+"""Predefined inflation profiles with rates and descriptions."""
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # SESSION STATE INITIALIZATION
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -642,7 +694,27 @@ def render(session: Session) -> None:
                 index=0,
                 )
         with c2:
-            inflation_pct = st.number_input("Inflation annuelle (%)", 0.0, 20.0, 2.0, 0.1)
+            _profile_labels = [p["label"] for p in _INFLATION_PROFILES]
+            _profile_index = st.selectbox(
+                "Profil d'inflation",
+                options=range(len(_INFLATION_PROFILES)),
+                format_func=lambda i: _INFLATION_PROFILES[i]["label"],
+                index=0,
+                key="sim_inflation_profile",
+                help="Choisir un profil prédéfini ou saisir un taux personnalisé.",
+                )
+            _selected_profile = _INFLATION_PROFILES[_profile_index]
+            if _selected_profile["rate"] is None:
+                inflation_pct = st.number_input(
+                    "Taux personnalisé (%)", 0.0, 30.0, 2.0, 0.1,
+                    key="sim_inflation_custom",
+                    )
+            else:
+                inflation_pct = _selected_profile["rate"]
+                st.caption(
+                    f"💡 {_selected_profile['description']}"
+                    )
+            _inflation_profile_label = _selected_profile["label"]
         with c3:
             income_start = st.number_input("Revenu brut annuel N (€)", 0.0, value=30000.0, step=1000.0)
             income_prev = st.number_input(
@@ -905,6 +977,7 @@ def render(session: Session) -> None:
         st.session_state.sim_config_params = {
             "years": int(years), "period": period,
             "inflation_pct": float(inflation_pct),
+            "inflation_profile": _inflation_profile_label,
             "income_start": float(income_start),
             "income_growth_pct": float(income_growth_pct),
             "annual_living_costs": float(annual_living_costs),

--- a/templates/simulation_report.html
+++ b/templates/simulation_report.html
@@ -255,7 +255,12 @@
             </tr>
             <tr>
                 <td>Inflation annuelle</td>
-                <td>{{ config_inflation }}</td>
+                <td>
+                    {{ config_inflation }}
+                    {% if config_inflation_profile %}
+                    <br><small style="color:#666;">{{ config_inflation_profile }}</small>
+                    {% endif %}
+                </td>
             </tr>
             <tr>
                 <td>Revenu brut initial</td>


### PR DESCRIPTION
## Summary

Implements issues **#1** (configurable inflation rate) and **#2** (README inflation section + app link).

---

## Changes

### Issue #1 — Configurable inflation rate

**`finance_tracker/web/views/simulation.py`**
- Added `_INFLATION_PROFILES` constant (module-level) defining 4 predefined profiles:
  | Profile | Rate |
  |---|---|
  | 📊 Standard IPC | 2.0 %/yr |
  | 🏙️ Urban tenant | 2.3 %/yr |
  | 🏠 Urban life + property | 3.0 %/yr |
  | 📐 Indexed urban m² | 4.0 %/yr |
  | ✏️ Custom | free input |
- Replaced the plain `number_input` for inflation with a `selectbox` of profiles. When a preset is selected, its rate is used directly and a description caption is shown. The custom option reveals a numeric input.
- Added `inflation_profile` key in `sim_config_params` (session state) so the selected label is passed to PDF generation.

**`finance_tracker/services/simulation_pdf_service.py`**
- Pass `config_inflation_profile` to the Jinja2 template render call.

**`templates/simulation_report.html`**
- Display the profile label as a subtitle under the inflation rate in the *Paramètres de Simulation* table.

---

### Issue #2 — README inflation section + app documentation link

**`README.md`**
- Added `📊 Inflation paramétrable` bullet in *Fonctionnalités Principales*.
- Added dedicated **## 📊 Inflation Paramétrable** section with the profile table and source references (INSEE IPC, IRL ANIL, IGEDD/Friggit).

**`finance_tracker/web/app.py`**
- Added a `📖 Documentation (README)` `link_button` in the sidebar (just below navigation), pointing to the GitHub README page.

---

## Testing

- [ ] Open the Simulation page → the inflation field now shows a selectbox with 4 profiles + custom option
- [ ] Selecting a preset shows its description and applies its rate automatically
- [ ] Selecting "Personnalisé" reveals a manual number input
- [ ] Running a simulation and exporting to PDF shows the profile name alongside the inflation rate
- [ ] The README sidebar button links correctly to the GitHub README
- [ ] README renders the new inflation section and table correctly

Closes #1
Closes #2