### PR TITLE
feat: per-product dashboard with valuation curves and PRU lines (#5)

### DIFF
--- a/finance_tracker/services/dashboard_service.py
+++ b/finance_tracker/services/dashboard_service.py
@@ -8,7 +8,7 @@ from sqlmodel import Session
 from tabulate import tabulate
 
 # Local application
-from finance_tracker.domain.enums import TransactionType
+from finance_tracker.domain.enums import ProductType, TransactionType
 from finance_tracker.domain.models import Product, Transaction, Valuation
 from finance_tracker.repositories.sqlmodel_repo import (
     SQLModelProductRepository,
@@ -16,6 +16,19 @@ from finance_tracker.repositories.sqlmodel_repo import (
     SQLModelValuationRepository,
     )
 from finance_tracker.utils.money import format_eur, round_decimal, safe_divide
+
+
+PRODUCT_COLORS = {
+    "BITCOIN": "#F7931A",
+    "SCPI": "#2563EB",
+    "CASH": "#16A34A",
+    "SAVINGS": "#8B5CF6",
+    "INSURANCE": "#EC4899",
+    "PER": "#F59E0B",
+    "FCPI": "#06B6D4",
+    }
+
+DEPOSIT_BASED_TYPES = {ProductType.CASH, ProductType.SAVINGS, ProductType.INSURANCE, ProductType.PER}
 
 
 class PortfolioData:
@@ -204,6 +217,99 @@ class DashboardService:
                 net -= tx.amount_eur
 
         return net
+
+    def get_product_history(self, product_id: int) -> list[dict]:
+        """Return chronological list of valuations for a product.
+
+        Each dict: {date, total_value_eur, unit_price_eur}
+        """
+        valuations = self.valuation_repo.get_by_product_id(product_id)
+        return [
+            {
+                "date": v.date,
+                "total_value_eur": float(v.total_value_eur),
+                "unit_price_eur": float(v.unit_price_eur) if v.unit_price_eur else None,
+                }
+            for v in valuations
+            ]
+
+    def get_product_pru(self, product_id: int) -> float | None:
+        """Calculate PRU for a product.
+
+        For BUY-based products: sum(BUY amount_eur) / quantity from latest valuation.
+        For DEPOSIT-based products: sum(DEPOSIT amount_eur).
+        Returns None if no data.
+        """
+        product = self.product_repo.get_by_id(product_id)
+        if not product:
+            return None
+
+        transactions = self.transaction_repo.get_by_product_id(product_id)
+
+        if product.type in DEPOSIT_BASED_TYPES:
+            total = sum(
+                float(t.amount_eur)
+                for t in transactions
+                if t.type == TransactionType.DEPOSIT and t.amount_eur
+                )
+            return total if total > 0 else None
+
+        # BUY-based products (BITCOIN, SCPI, FCPI)
+        buy_total = sum(
+            float(t.amount_eur)
+            for t in transactions
+            if t.type == TransactionType.BUY and t.amount_eur
+            )
+        if buy_total <= 0:
+            return None
+
+        latest_val = self.valuation_repo.get_latest_by_product_id(product_id)
+        if not latest_val or not latest_val.unit_price_eur or float(latest_val.unit_price_eur) <= 0:
+            return None
+
+        total_value = float(latest_val.total_value_eur)
+        unit_price = float(latest_val.unit_price_eur)
+        if unit_price <= 0:
+            return None
+
+        quantity = total_value / unit_price
+        if quantity <= 0:
+            return None
+
+        return buy_total / quantity
+
+    def get_product_details(self, product_id: int) -> dict | None:
+        """Return comprehensive per-product data for dashboard display."""
+        product = self.product_repo.get_by_id(product_id)
+        if not product:
+            return None
+
+        history = self.get_product_history(product_id)
+        pru = self.get_product_pru(product_id)
+
+        latest_val = self.valuation_repo.get_latest_by_product_id(product_id)
+        current_value = float(latest_val.total_value_eur) if latest_val else 0.0
+
+        transactions = self.transaction_repo.get_by_product_id(product_id)
+        net_invested = float(self._calc_net_contributions(transactions))
+
+        gains_eur = current_value - net_invested
+        gains_pct = (gains_eur / net_invested * 100) if net_invested > 0 else 0.0
+
+        color = PRODUCT_COLORS.get(product.type.value, "#6B7280")
+
+        return {
+            "id": product.id,
+            "name": product.name,
+            "type": product.type.value,
+            "color": color,
+            "history": history,
+            "pru": pru,
+            "current_value": current_value,
+            "net_invested": net_invested,
+            "gains_eur": gains_eur,
+            "gains_pct": gains_pct,
+            }
 
     def display_dashboard(self, portfolio: PortfolioData) -> str:
         """Format a text dashboard display using tabulate.

--- a/finance_tracker/services/pdf_report_service.py
+++ b/finance_tracker/services/pdf_report_service.py
@@ -12,7 +12,7 @@ from weasyprint import HTML, CSS
 
 # Local application
 from finance_tracker.config import REPORTS_DIR, TEMPLATES_DIR
-from finance_tracker.services.dashboard_service import PortfolioData
+from finance_tracker.services.dashboard_service import PRODUCT_COLORS, PortfolioData
 from finance_tracker.utils.money import format_eur
 
 
@@ -23,13 +23,16 @@ class PDFReportService:
         self.templates_dir = templates_dir
         self.reports_dir = reports_dir
 
-    def generate_report(self, portfolio: PortfolioData) -> str:
+    def generate_report(self, portfolio: PortfolioData, products_with_charts: list | None = None) -> str:
         """Generate a PDF report and save it to disk.
 
         Parameters
         ----------
         portfolio : PortfolioData
             Portfolio data to export as PDF.
+        products_with_charts : list | None
+            Optional list of per-product detail dicts (from DashboardService.get_product_details)
+            to include per-product valuation charts in the report.
 
         Returns
         -------
@@ -37,7 +40,7 @@ class PDFReportService:
             Path to the generated PDF file.
         """
         # Render template to HTML first, then convert to PDF
-        html_content = self._render_html(portfolio)
+        html_content = self._render_html(portfolio, products_with_charts)
 
         # Use timestamp in filename to ensure uniqueness and traceability
         timestamp = datetime.utcnow().strftime("%Y-%m-%d_%H%M%S")
@@ -49,13 +52,15 @@ class PDFReportService:
 
         return str(filepath)
 
-    def _render_html(self, portfolio: PortfolioData) -> str:
+    def _render_html(self, portfolio: PortfolioData, products_with_charts: list | None = None) -> str:
         """Render portfolio data using Jinja2 template.
 
         Parameters
         ----------
         portfolio : PortfolioData
             Portfolio data to render.
+        products_with_charts : list | None
+            Optional per-product detail dicts for chart sections.
 
         Returns
         -------
@@ -79,6 +84,30 @@ class PDFReportService:
         # Generate charts as base64 images to embed directly in HTML
         chart_allocation = self._generate_allocation_chart(portfolio.products)
         chart_performance = self._generate_performance_chart(portfolio.products)
+
+        # Build per-product chart data for the template
+        product_chart_data = []
+        if products_with_charts:
+            for details in products_with_charts:
+                if not details.get("history") or len(details["history"]) < 2:
+                    continue
+                chart_b64 = self._generate_product_history_chart(
+                    details["name"],
+                    details["history"],
+                    details.get("pru"),
+                    details.get("color", "#6B7280"),
+                    )
+                gains_class = "positive" if details["gains_eur"] >= 0 else "negative"
+                product_chart_data.append({
+                    "name": details["name"],
+                    "current_value": format_eur(details["current_value"]),
+                    "net_invested": format_eur(details["net_invested"]),
+                    "pru": format_eur(details["pru"]) if details.get("pru") else "—",
+                    "gains_eur": format_eur(details["gains_eur"]),
+                    "gains_pct": f"{details['gains_pct']:.2f}%",
+                    "gains_class": gains_class,
+                    "chart_base64": chart_b64,
+                    })
 
         # Pass both raw values and formatted strings to template
         # Raw values enable calculations in template if needed
@@ -108,6 +137,7 @@ class PDFReportService:
 
                 for p in portfolio.products
                 ],
+            products_with_charts=product_chart_data,
             )
 
     def _generate_allocation_chart(self, products: list) -> str:
@@ -283,6 +313,66 @@ class PDFReportService:
         # Remove unnecessary frame borders for cleaner look
 
         for spine in ["top", "right", "left"]:
+            ax.spines[spine].set_visible(False)
+
+        plt.tight_layout()
+
+        img_buffer = BytesIO()
+        plt.savefig(img_buffer, format="png", bbox_inches="tight")
+        img_buffer.seek(0)
+        img_str = base64.b64encode(img_buffer.read()).decode()
+        plt.close(fig)
+
+        return f"data:image/png;base64,{img_str}"
+
+    def _generate_product_history_chart(
+        self,
+        product_name: str,
+        history: list[dict],
+        pru: float | None,
+        color: str = "#008080",
+    ) -> str:
+        """Generate a line chart for a product's valuation history with optional PRU line.
+
+        Returns base64-encoded PNG data URL.
+        """
+        import matplotlib as mpl
+        import matplotlib.dates as mdates
+
+        dates = [h["date"] for h in history]
+        values = [h["total_value_eur"] for h in history]
+
+        mpl.rcParams.update({
+            "font.size": 10,
+            "axes.titlesize": 12,
+            "axes.edgecolor": "#E5E7EB",
+            "axes.labelcolor": "#333",
+            "xtick.color": "#666",
+            "ytick.color": "#333",
+            })
+
+        fig, ax = plt.subplots(figsize=(10, 4), dpi=160)
+        fig.patch.set_facecolor("white")
+        ax.set_facecolor("white")
+
+        ax.plot(dates, values, color=color, linewidth=2.2, marker="o", markersize=4, zorder=3)
+        ax.fill_between(dates, values, alpha=0.10, color=color, zorder=2)
+
+        if pru is not None:
+            ax.axhline(y=pru, color="#6366f1", linewidth=1.6, linestyle="--", zorder=2, label=f"PRU ({pru:,.0f} €)")
+            ax.legend(loc="upper left", fontsize=9, frameon=False)
+
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %Y"))
+        ax.xaxis.set_major_locator(mdates.AutoDateLocator())
+        fig.autofmt_xdate(rotation=30)
+
+        ax.yaxis.grid(True, color="#E5E7EB", linewidth=0.8, alpha=0.8)
+        ax.set_axisbelow(True)
+
+        ax.set_ylabel("Valeur (€)")
+        ax.set_title(f"Historique — {product_name}", pad=12)
+
+        for spine in ["top", "right"]:
             ax.spines[spine].set_visible(False)
 
         plt.tight_layout()

--- a/finance_tracker/web/views/dashboard.py
+++ b/finance_tracker/web/views/dashboard.py
@@ -191,6 +191,106 @@ def render(session: Session) -> None:
     st.markdown("---")
 
     # ═══════════════════════════════════════════════════════════════════════════
+    # SECTION 2b: PER-PRODUCT DETAIL SECTIONS
+    # ═══════════════════════════════════════════════════════════════════════════
+
+    st.markdown("### 🔍 Détail par produit")
+
+    for p in portfolio.products:
+        if p.get("current_value_eur", 0) <= 0:
+            continue
+
+        product_id = p["id"]
+        details = service.get_product_details(product_id)
+        if not details or not details["history"]:
+            continue
+
+        with st.expander(f"**{p['name']}** — {format_eur(details['current_value'])}"):
+            # Mini KPI row
+            k1, k2, k3, k4 = st.columns(4)
+            with k1:
+                st.metric("Valeur actuelle", format_eur(details["current_value"]))
+            with k2:
+                st.metric("Investi net", format_eur(details["net_invested"]))
+            with k3:
+                st.metric(
+                    "Gains",
+                    format_eur(details["gains_eur"]),
+                    delta=f"{details['gains_pct']:.2f}%",
+                    delta_color="normal",
+                    )
+            with k4:
+                if details["pru"] is not None:
+                    st.metric("PRU", format_eur(details["pru"]))
+                else:
+                    st.metric("PRU", "—")
+
+            # Valuation curve chart
+            if len(details["history"]) >= 2:
+                chart_df = pd.DataFrame(details["history"])
+                chart_df["date"] = pd.to_datetime(chart_df["date"])
+
+                base = alt.Chart(chart_df).encode(
+                    x=alt.X("date:T", title="Date", axis=alt.Axis(format="%b %Y")),
+                    )
+
+                area = base.mark_area(
+                    color=details["color"],
+                    opacity=0.15,
+                    line={"color": details["color"], "strokeWidth": 2.5},
+                    ).encode(
+                        y=alt.Y("total_value_eur:Q", title="Valeur (€)"),
+                        tooltip=[
+                            alt.Tooltip("date:T", title="Date", format="%d/%m/%Y"),
+                            alt.Tooltip("total_value_eur:Q", title="Valeur (€)", format=",.2f"),
+                            ],
+                        )
+
+                points = base.mark_circle(color=details["color"], size=40).encode(
+                    y="total_value_eur:Q",
+                    )
+
+                chart = (area + points).properties(height=240)
+
+                # Add PRU line if available
+                if details["pru"] is not None:
+                    pru_df = pd.DataFrame([
+                        {"date": chart_df["date"].min(), "PRU": details["pru"]},
+                        {"date": chart_df["date"].max(), "PRU": details["pru"]},
+                        ])
+                    pru_line = alt.Chart(pru_df).mark_line(
+                        color="#6366f1", strokeDash=[6, 4], strokeWidth=1.8,
+                        ).encode(
+                            x="date:T",
+                            y=alt.Y("PRU:Q"),
+                            tooltip=[alt.Tooltip("PRU:Q", title="PRU (€)", format=",.2f")],
+                            )
+                    chart = (chart + pru_line).properties(height=240)
+
+                st.altair_chart(chart, use_container_width=True)
+
+                legend_parts = [f"<span style='color:{details['color']}'>■</span> Valeur"]
+                if details["pru"] is not None:
+                    legend_parts.append("<span style='color:#6366f1'>- -</span> PRU")
+                st.caption(" · ".join(legend_parts))
+
+            # Recent valuations table
+            recent = list(reversed(details["history"]))[:8]
+            if recent:
+                table_rows = []
+                for v in recent:
+                    row = {
+                        "Date": v["date"].strftime("%d/%m/%Y") if hasattr(v["date"], "strftime") else str(v["date"]),
+                        "Valeur (€)": f"{v['total_value_eur']:,.2f}".replace(",", " "),
+                        }
+                    if v.get("unit_price_eur"):
+                        row["Prix unitaire (€)"] = f"{v['unit_price_eur']:,.2f}".replace(",", " ")
+                    table_rows.append(row)
+                st.dataframe(pd.DataFrame(table_rows), hide_index=True, use_container_width=True)
+
+    st.markdown("---")
+
+    # ═══════════════════════════════════════════════════════════════════════════
     # SECTION 3: EXPORTS & REPORTS
     # ═══════════════════════════════════════════════════════════════════════════
 
@@ -211,8 +311,16 @@ def render(session: Session) -> None:
             if st.button("⚙️ Préparer le rapport PDF", width="stretch"):
                 with st.spinner("⏳ Génération du rapport PDF..."):
                     try:
+                        # Build per-product chart data for PDF
+                        chart_details = []
+                        for p in portfolio.products:
+                            if p.get("current_value_eur", 0) > 0:
+                                d = service.get_product_details(p["id"])
+                                if d and d.get("history") and len(d["history"]) >= 2:
+                                    chart_details.append(d)
+
                         pdf_service = PDFReportService()
-                        filepath = pdf_service.generate_report(portfolio)
+                        filepath = pdf_service.generate_report(portfolio, chart_details or None)
 
                         # Read and cache PDF bytes
                         with open(filepath, "rb") as f:

--- a/templates/report.html
+++ b/templates/report.html
@@ -8,147 +8,121 @@
     @page {
       size: A4;
       margin: 18mm 14mm;
-      @bottom-left { content: "Finance Tracker — Rapport Portefeuille"; font-size: 9pt; color: #6b7280; }
-      @bottom-right { content: "Page " counter(page) " / " counter(pages); font-size: 9pt; color: #6b7280; }
+      @bottom-left { content: "Finance Tracker — Rapport Portefeuille"; font-size: 9pt; color: #666; }
+      @bottom-right { content: "Page " counter(page) " / " counter(pages); font-size: 9pt; color: #666; }
     }
 
-    * { box-sizing: border-box; }
-    html, body { margin: 0; padding: 0; }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
-      color: #111827;
-      line-height: 1.35;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: #333;
+      line-height: 1.5;
       font-size: 11pt;
       background: #ffffff;
     }
 
     .container { width: 100%; max-width: 100%; }
 
+    /* ===== Header — teal accent ===== */
     .header {
-      padding-bottom: 14px;
-      border-bottom: 2px solid #e5e7eb;
-      margin-bottom: 18px;
+      text-align: center;
+      padding: 20px 0;
+      border-bottom: 2px solid #008080;
+      margin-bottom: 30px;
     }
-    .header-top {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-end;
-      gap: 12px;
+    .header h1 {
+      font-size: 24pt;
+      color: #008080;
+      margin-bottom: 5px;
     }
-    .title-block h1 {
-      margin: 0;
-      font-size: 22pt;
-      letter-spacing: 0.2px;
-      color: #0f172a;
-    }
-    .subtitle {
-      margin-top: 4px;
+    .header p {
       font-size: 10pt;
-      color: #6b7280;
-    }
-    .meta {
-      text-align: right;
-      font-size: 10pt;
-      color: #6b7280;
-      white-space: nowrap;
+      color: #666;
     }
 
-    .section { margin-top: 18px; }
+    /* ===== Sections ===== */
+    .section { margin-bottom: 30px; }
     .section h2 {
-      margin: 0 0 10px 0;
-      padding-bottom: 6px;
-      border-bottom: 1px solid #e5e7eb;
-      font-size: 13pt;
-      color: #111827;
+      font-size: 14pt;
+      color: #008080;
+      border-bottom: 1px solid #ddd;
+      padding-bottom: 8px;
+      margin-bottom: 15px;
+      page-break-after: avoid;
+    }
+    .section h3 {
+      font-size: 12pt;
+      color: #333;
+      margin-top: 15px;
+      margin-bottom: 10px;
     }
 
-    /* 2 colonnes fixes, prend toute la largeur disponible */
-    .summary{
+    /* ===== Summary cards — teal left border (matches simulation_report) ===== */
+    .summary-grid {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 12px;
-      width: 100%;
+      grid-template-columns: 1fr 1fr;
+      gap: 15px;
+      margin-bottom: 20px;
     }
-    /* Très important en CSS Grid: autoriser les items à rétrécir */
-    .card{
+    .summary-card {
+      background: #f9f9f9;
+      border: 1px solid #e0e0e0;
+      border-left: 4px solid #008080;
+      padding: 15px;
+      border-radius: 4px;
       min-width: 0;
     }
-    /* Empêcher la note / texte long de “pousser” la colonne */
-    .note{
-      min-width: 0;
-      overflow-wrap: anywhere;
-      word-break: break-word;
+    .summary-card .label {
+      font-size: 9pt;
+      color: #666;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 5px;
     }
-    .card-value{
+    .summary-card .value {
+      font-size: 14pt;
+      font-weight: bold;
+      color: #008080;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    .card {
-      border: 1px solid #e5e7eb;
-      border-radius: 10px;
-      padding: 16px 14px 14px 14px;
-      background: linear-gradient(135deg, #ffffff 0%, #fafbfc 100%);
-    }
-    .card-label {
-      font-size: 9pt;
-      color: #6b7280;
-      text-transform: uppercase;
-      letter-spacing: 0.6px;
-      margin-bottom: 6px;
-      line-height: 1.2;
-    }
-    .card-value {
-      font-size: 16pt;
-      font-weight: 700;
-      color: #0f172a;
-      margin-bottom: 4px;
-    }
-    .card-hint {
+    .summary-card .hint {
       margin-top: 6px;
       font-size: 9pt;
-      color: #6b7280;
+      color: #666;
       line-height: 1.3;
     }
 
     .positive { color: #16a34a; }
     .negative { color: #dc2626; }
 
-    /* ===== Charts (1 colonne = grands) ===== */
+    /* ===== Charts ===== */
     .charts {
       display: grid;
       grid-template-columns: 1fr;
       gap: 16px;
       margin-top: 16px;
     }
-    .chart {
-      border: 1px solid #e5e7eb;
-      border-radius: 10px;
-      padding: 16px;
+    .chart-container {
+      margin: 25px 0;
+      text-align: center;
       page-break-inside: avoid;
     }
-    .chart h3 {
-      margin: 0 0 12px 0;
-      font-size: 12pt;
-      color: #0f172a;
-    }
-    .chart img {
-      width: 100%;
+    .chart-container img {
+      max-width: 100%;
       height: auto;
-      max-height: 450px;
-      object-fit: contain;
-      border: 1px solid #eef2f7;
-      border-radius: 8px;
-      display: block;
-      background: #ffffff;
+      border: 1px solid #ddd;
+      border-radius: 4px;
     }
-    .chart-note {
-      margin-top: 10px;
-      font-size: 9pt;
-      color: #6b7280;
+    .chart-title {
+      font-size: 10pt;
+      color: #666;
+      margin-top: 8px;
+      font-style: italic;
     }
 
-    /* ===== Table ===== */
+    /* ===== Table — teal headers (matches simulation_report) ===== */
     table {
       width: 100%;
       border-collapse: collapse;
@@ -156,21 +130,21 @@
       font-size: 10pt;
     }
     thead th {
-      background: #f8fafc;
-      color: #111827;
+      background: #008080;
+      color: white;
       font-weight: 700;
-      border-bottom: 2px solid #e5e7eb;
-      padding: 12px 10px;
+      padding: 10px 10px;
+      text-align: left;
       text-transform: uppercase;
       letter-spacing: 0.4px;
       font-size: 9pt;
     }
     tbody td {
-      border-bottom: 1px solid #eef2f7;
-      padding: 11px 10px;
+      border-bottom: 1px solid #ddd;
+      padding: 10px 10px;
       vertical-align: middle;
     }
-    tbody tr:nth-child(even) { background: #fcfcfd; }
+    tbody tr:nth-child(even) { background: #f9f9f9; }
 
     td:first-child, th:first-child { text-align: left; }
     td:not(:first-child), th:not(:first-child) { text-align: right; }
@@ -180,101 +154,123 @@
     .col-perf { width: 12%; }
     .col-alloc { width: 10%; }
 
+    /* ===== Per-product section ===== */
+    .product-section {
+      page-break-inside: avoid;
+      margin-bottom: 25px;
+    }
+    .product-section h3 {
+      font-size: 13pt;
+      color: #008080;
+      margin-bottom: 10px;
+    }
+    .product-kpis {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+      gap: 12px;
+      margin-bottom: 15px;
+    }
+
     /* ===== Notes ===== */
     .note {
       font-size: 9.5pt;
-      color: #6b7280;
+      color: #666;
       margin-top: 12px;
       line-height: 1.4;
       padding: 12px;
-      background: #f9fafb;
-      border-left: 3px solid #d1d5db;
+      background: #f9f9f9;
+      border-left: 3px solid #008080;
       border-radius: 4px;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
-    .hr {
-      height: 1px;
-      background: linear-gradient(to right, transparent, #e5e7eb, transparent);
-      margin: 20px 0;
+
+    /* ===== Footer (matches simulation_report) ===== */
+    footer {
+      margin-top: 40px;
+      padding-top: 20px;
+      border-top: 1px solid #ddd;
+      font-size: 9pt;
+      color: #999;
+      text-align: center;
     }
   </style>
 </head>
 
 <body>
   <div class="container">
+    <!-- HEADER -->
     <div class="header">
-      <div class="header-top">
-        <div class="title-block">
-          <h1>Rapport Portefeuille</h1>
-          <div class="subtitle">Synthèse complète et analyses</div>
-        </div>
-        <div class="meta">Généré le {{ generated_at }}</div>
-      </div>
+      <h1>Rapport Portefeuille</h1>
+      <p>Synthèse complète et analyses — {{ generated_at }}</p>
     </div>
 
+    <!-- SECTION 1: RÉSUMÉ GLOBAL -->
     <div class="section">
       <h2>Résumé global</h2>
-      <div class="summary">
-        <div class="card">
-          <div class="card-label">Valeur totale</div>
-          <div class="card-value">{{ total_value_eur }}</div>
-          <div class="card-hint">Valeur estimée à date de génération</div>
+      <div class="summary-grid">
+        <div class="summary-card">
+          <div class="label">Valeur totale</div>
+          <div class="value">{{ total_value_eur }}</div>
+          <div class="hint">Valeur estimée à date de génération</div>
         </div>
 
-        <div class="card">
-          <div class="card-label">Investissement net</div>
-          <div class="card-value">{{ total_invested_eur }}</div>
-          <div class="card-hint">Dépôts – retraits (+/- flux)</div>
+        <div class="summary-card">
+          <div class="label">Investissement net</div>
+          <div class="value">{{ total_invested_eur }}</div>
+          <div class="hint">Dépôts – retraits (+/- flux)</div>
         </div>
 
-        <div class="card">
-          <div class="card-label">Gains nets</div>
-          <div class="card-value {{ total_gains_class }}">{{ total_gains_eur_formatted }}</div>
-          <div class="card-hint">Valeur totale – investissement net</div>
+        <div class="summary-card">
+          <div class="label">Gains nets</div>
+          <div class="value {{ total_gains_class }}">{{ total_gains_eur_formatted }}</div>
+          <div class="hint">Valeur totale – investissement net</div>
         </div>
 
-        <div class="card">
-          <div class="card-label">Performance globale</div>
-          <div class="card-value {{ total_gains_class }}">{{ total_gains_pct }}</div>
-          <div class="card-hint">Performance simple (gains/investi)</div>
+        <div class="summary-card">
+          <div class="label">Performance globale</div>
+          <div class="value {{ total_gains_class }}">{{ total_gains_pct }}</div>
+          <div class="hint">Performance simple (gains/investi)</div>
         </div>
 
-        <div class="card">
-          <div class="card-label">Liquidités disponibles</div>
-          <div class="card-value">{{ cash_available }}</div>
-          <div class="card-hint">Cash + épargne (mobilisables)</div>
+        <div class="summary-card">
+          <div class="label">Liquidités disponibles</div>
+          <div class="value">{{ cash_available }}</div>
+          <div class="hint">Cash + épargne (mobilisables)</div>
         </div>
 
-        <div class="card">
-          <div class="card-label">Lecture rapide</div>
+        <div class="summary-card">
+          <div class="label">Lecture rapide</div>
           <div class="note">
-            <strong>Performance :</strong> Les graphiques et métriques dépendent de la fraîcheur des valorisations. Si un produit n’a pas été valorisé depuis > 1 mois, le rapport peut sous/surestimer sa performance.<br>
+            <strong>Performance :</strong> Les graphiques et métriques dépendent de la fraîcheur des valorisations. Si un produit n'a pas été valorisé depuis > 1 mois, le rapport peut sous/surestimer sa performance.<br>
             <strong>Conseil :</strong> Valorise mensuellement SCPI/Bitcoin, trimestriellement AV/PER.
           </div>
         </div>
       </div>
     </div>
 
+    <!-- SECTION 2: ANALYSES GRAPHIQUES -->
     <div class="section">
       <h2>Analyses graphiques</h2>
       <div class="charts">
         {% if chart_allocation %}
-        <div class="chart">
-          <h3>Répartition du portefeuille</h3>
+        <div class="chart-container">
           <img src="{{ chart_allocation }}" alt="Répartition par produit" />
-          <div class="chart-note">Allocation actuelle. Conseil : 40-60% stable (SCPI, cash), 40-60% croissance (Bitcoin, actions).</div>
+          <div class="chart-title">Répartition du portefeuille — Allocation actuelle</div>
         </div>
         {% endif %}
 
         {% if chart_performance %}
-        <div class="chart">
-          <h3>Performance absolue par produit</h3>
+        <div class="chart-container">
           <img src="{{ chart_performance }}" alt="Performance absolue par produit" />
-          <div class="chart-note">Gains nets par produit. Barres vertes = positif, rouges = négatif. Performance simple (valeur – investi).</div>
+          <div class="chart-title">Performance par produit — Gains nets (valeur – investi)</div>
         </div>
         {% endif %}
       </div>
     </div>
 
+    <!-- SECTION 3: DÉTAIL PAR PRODUIT (TABLE) -->
     <div class="section">
       <h2>Détail par produit</h2>
       <table>
@@ -303,10 +299,46 @@
       </table>
     </div>
 
-    <div class="hr"></div>
-    <div class="note">
-      <strong>Finance Tracker</strong> — Rapport généré automatiquement. Données à titre informatif uniquement, sans valeur de conseil en investissement.
+    <!-- SECTION 4: HISTORIQUE PAR PRODUIT (CHARTS) -->
+    {% if products_with_charts %}
+    <div class="section">
+      <h2>Historique par Produit</h2>
+
+      {% for product in products_with_charts %}
+      <div class="product-section">
+        <h3>{{ product.name }}</h3>
+
+        <div class="product-kpis">
+          <div class="summary-card">
+            <div class="label">Valeur actuelle</div>
+            <div class="value">{{ product.current_value }}</div>
+          </div>
+          <div class="summary-card">
+            <div class="label">Investi net</div>
+            <div class="value">{{ product.net_invested }}</div>
+          </div>
+          <div class="summary-card">
+            <div class="label">PRU</div>
+            <div class="value">{{ product.pru }}</div>
+          </div>
+          <div class="summary-card">
+            <div class="label">Gains</div>
+            <div class="value {{ product.gains_class }}">{{ product.gains_eur }} ({{ product.gains_pct }})</div>
+          </div>
+        </div>
+
+        <div class="chart-container">
+          <img src="{{ product.chart_base64 }}" alt="Historique {{ product.name }}" />
+        </div>
+      </div>
+      {% endfor %}
     </div>
+    {% endif %}
+
+    <!-- FOOTER -->
+    <footer>
+      <p>Généré automatiquement — Finance Tracker</p>
+    </footer>
   </div>
 </body>
 </html>

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -1,0 +1,210 @@
+"""Tests for DashboardService per-product methods."""
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from finance_tracker.domain.enums import ProductType, QuantityUnit, TransactionType
+from finance_tracker.domain.models import Product, Transaction, Valuation
+from finance_tracker.services.dashboard_service import (
+    DEPOSIT_BASED_TYPES,
+    PRODUCT_COLORS,
+    DashboardService,
+)
+
+
+@pytest.fixture()
+def session():
+    """Create an in-memory SQLite session with tables."""
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as s:
+        yield s
+
+
+@pytest.fixture()
+def bitcoin_product(session):
+    """Seed a Bitcoin product with valuations and BUY transactions."""
+    product = Product(name="Bitcoin", type=ProductType.BITCOIN, quantity_unit=QuantityUnit.BTC_SATS)
+    session.add(product)
+    session.commit()
+    session.refresh(product)
+
+    # Two valuations
+    session.add(Valuation(
+        product_id=product.id,
+        date=datetime(2025, 1, 1),
+        total_value_eur=Decimal("5000"),
+        unit_price_eur=Decimal("50000"),
+    ))
+    session.add(Valuation(
+        product_id=product.id,
+        date=datetime(2025, 6, 1),
+        total_value_eur=Decimal("8000"),
+        unit_price_eur=Decimal("80000"),
+    ))
+
+    # BUY transaction: 4000 EUR
+    session.add(Transaction(
+        product_id=product.id,
+        date=datetime(2025, 1, 1),
+        type=TransactionType.BUY,
+        amount_eur=Decimal("4000"),
+        quantity=Decimal("0.08"),
+    ))
+    session.commit()
+    return product
+
+
+@pytest.fixture()
+def savings_product(session):
+    """Seed a savings product with DEPOSIT transactions."""
+    product = Product(name="Livret A", type=ProductType.SAVINGS, quantity_unit=QuantityUnit.NONE)
+    session.add(product)
+    session.commit()
+    session.refresh(product)
+
+    session.add(Valuation(
+        product_id=product.id,
+        date=datetime(2025, 3, 1),
+        total_value_eur=Decimal("10500"),
+        unit_price_eur=None,
+    ))
+
+    session.add(Transaction(
+        product_id=product.id,
+        date=datetime(2025, 1, 1),
+        type=TransactionType.DEPOSIT,
+        amount_eur=Decimal("10000"),
+    ))
+    session.commit()
+    return product
+
+
+@pytest.fixture()
+def empty_product(session):
+    """Seed a product with no valuations or transactions."""
+    product = Product(name="Empty", type=ProductType.CASH, quantity_unit=QuantityUnit.NONE)
+    session.add(product)
+    session.commit()
+    session.refresh(product)
+    return product
+
+
+class TestGetProductHistory:
+    def test_returns_chronological_valuations(self, session, bitcoin_product):
+        svc = DashboardService(session)
+        history = svc.get_product_history(bitcoin_product.id)
+
+        assert len(history) == 2
+        assert history[0]["date"] == datetime(2025, 1, 1)
+        assert history[1]["date"] == datetime(2025, 6, 1)
+        assert history[0]["total_value_eur"] == 5000.0
+        assert history[1]["total_value_eur"] == 8000.0
+
+    def test_empty_history(self, session, empty_product):
+        svc = DashboardService(session)
+        history = svc.get_product_history(empty_product.id)
+
+        assert history == []
+
+    def test_includes_unit_price(self, session, bitcoin_product):
+        svc = DashboardService(session)
+        history = svc.get_product_history(bitcoin_product.id)
+
+        assert history[0]["unit_price_eur"] == 50000.0
+        assert history[1]["unit_price_eur"] == 80000.0
+
+    def test_null_unit_price(self, session, savings_product):
+        svc = DashboardService(session)
+        history = svc.get_product_history(savings_product.id)
+
+        assert len(history) == 1
+        assert history[0]["unit_price_eur"] is None
+
+
+class TestGetProductPru:
+    def test_buy_based_pru(self, session, bitcoin_product):
+        svc = DashboardService(session)
+        pru = svc.get_product_pru(bitcoin_product.id)
+
+        # BUY total = 4000 EUR, latest valuation: 8000 / 80000 = 0.1 BTC
+        # PRU = 4000 / 0.1 = 40000
+        assert pru is not None
+        assert abs(pru - 40000.0) < 1.0
+
+    def test_deposit_based_pru(self, session, savings_product):
+        svc = DashboardService(session)
+        pru = svc.get_product_pru(savings_product.id)
+
+        # DEPOSIT total = 10000
+        assert pru == 10000.0
+
+    def test_no_transactions_returns_none(self, session, empty_product):
+        svc = DashboardService(session)
+        pru = svc.get_product_pru(empty_product.id)
+
+        assert pru is None
+
+    def test_nonexistent_product_returns_none(self, session):
+        svc = DashboardService(session)
+        pru = svc.get_product_pru(99999)
+
+        assert pru is None
+
+    def test_deposit_types_constant(self):
+        assert ProductType.CASH in DEPOSIT_BASED_TYPES
+        assert ProductType.SAVINGS in DEPOSIT_BASED_TYPES
+        assert ProductType.INSURANCE in DEPOSIT_BASED_TYPES
+        assert ProductType.PER in DEPOSIT_BASED_TYPES
+        assert ProductType.BITCOIN not in DEPOSIT_BASED_TYPES
+
+
+class TestGetProductDetails:
+    def test_returns_full_structure(self, session, bitcoin_product):
+        svc = DashboardService(session)
+        details = svc.get_product_details(bitcoin_product.id)
+
+        assert details is not None
+        assert details["name"] == "Bitcoin"
+        assert details["type"] == "BITCOIN"
+        assert details["color"] == "#F7931A"
+        assert len(details["history"]) == 2
+        assert details["pru"] is not None
+        assert details["current_value"] == 8000.0
+        assert details["net_invested"] == 4000.0
+        assert details["gains_eur"] == 4000.0
+        assert abs(details["gains_pct"] - 100.0) < 0.1
+
+    def test_nonexistent_returns_none(self, session):
+        svc = DashboardService(session)
+        details = svc.get_product_details(99999)
+
+        assert details is None
+
+    def test_empty_product_details(self, session, empty_product):
+        svc = DashboardService(session)
+        details = svc.get_product_details(empty_product.id)
+
+        assert details is not None
+        assert details["current_value"] == 0.0
+        assert details["history"] == []
+        assert details["pru"] is None
+
+    def test_savings_product_details(self, session, savings_product):
+        svc = DashboardService(session)
+        details = svc.get_product_details(savings_product.id)
+
+        assert details is not None
+        assert details["name"] == "Livret A"
+        assert details["color"] == PRODUCT_COLORS["SAVINGS"]
+        assert details["current_value"] == 10500.0
+        assert details["net_invested"] == 10000.0
+        assert details["gains_eur"] == 500.0
+
+
+class TestProductColors:
+    def test_all_product_types_have_colors(self):
+        for pt in ProductType:
+            assert pt.value in PRODUCT_COLORS, f"Missing color for {pt.value}"


### PR DESCRIPTION
## Summary

- **DashboardService**: Added `get_product_history()`, `get_product_pru()`, and `get_product_details()` methods supporting both BUY-based (Bitcoin, SCPI, FCPI) and DEPOSIT-based (Cash, Savings, Insurance, PER) PRU calculation
- **Streamlit dashboard**: Added collapsible per-product sections below the global overview, each with mini KPIs (value, invested, gains, PRU), Altair area chart with valuation curve + dashed PRU reference line, and recent valuations table
- **PDF report**: Added per-product historical valuation charts (matplotlib) with PRU lines embedded as base64 images, with KPI summary cards per product
- **Visual coherence**: Updated `report.html` to match `simulation_report.html` teal (#008080) color scheme — teal headers, `.summary-card` with left border accent, teal table headers, matching typography and footer
- **Tests**: 14 new tests in `tests/test_dashboard_service.py` covering all service methods, edge cases (empty data, nonexistent products, zero values), and product color map completeness

Closes #5

## Test plan

- [x] All 14 new tests pass (`pytest tests/test_dashboard_service.py -v`)
- [ ] Manual verification: open dashboard with seeded data, verify per-product expanders render with charts
- [ ] Manual verification: generate PDF report and confirm per-product chart sections appear
- [ ] Visual check: compare report.html and simulation_report.html PDFs for consistent teal styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)