### PR TITLE
fix/feat: legend HTML rendering + merge Bitcoin view into dashboard

### DIFF
--- a/finance_tracker/web/views/dashboard.py
+++ b/finance_tracker/web/views/dashboard.py
@@ -272,7 +272,10 @@ def render(session: Session) -> None:
                 legend_parts = [f"<span style='color:{details['color']}'>■</span> Valeur"]
                 if details["pru"] is not None:
                     legend_parts.append("<span style='color:#6366f1'>- -</span> PRU")
-                st.caption(" · ".join(legend_parts))
+                st.markdown(
+                    "<span style='font-size:0.85em;color:gray'>" + " · ".join(legend_parts) + "</span>",
+                    unsafe_allow_html=True,
+                )
 
             # Recent valuations table
             recent = list(reversed(details["history"]))[:8]


### PR DESCRIPTION
## Summary

- **Fixes #10** — `st.caption()` affichait les balises `<span>` en texte brut. Remplacé par `st.markdown(..., unsafe_allow_html=True)` pour que la légende colorée s'affiche correctement.
- **Fixes #11** — La page Bitcoin et le dashboard avaient une duplication fonctionnelle. Toutes les fonctionnalités Bitcoin sont désormais intégrées dans le Tableau de Bord, section "Détail par produit".

## Changements

### `dashboard.py`
- Refactorisé la section "Détail par produit" en deux fonctions : `_render_bitcoin_expander` et `_render_generic_expander`
- `_render_bitcoin_expander` contient toutes les fonctionnalités de l'ancienne `bitcoin.py` :
  - Panneau hero avec cours live BTC/EUR + badge LIVE/OFFLINE
  - Bouton d'actualisation du cours (BTCPriceService)
  - Métriques : valeur, quantité en Satoshis, PRU, P&L latente
  - Graphique d'historique des prix (unit_price_eur) avec ligne PRU
  - Formulaire de nouveau snapshot (saisie en Satoshis, calcul automatique)
  - Tableau des derniers snapshots enrichi (Date, Prix BTC, Satoshis, Valeur)

### `bitcoin.py`
- Converti en page de transition : affiche un message clair orientant l'utilisateur vers le Tableau de Bord, sans supprimer l'entrée de navigation

## Test plan

- [ ] Dashboard → Détail par produit → Bitcoin : vérifier panneau hero, métriques Sats et P&L, graphique prix, formulaire snapshot fonctionnel, tableau enrichi
- [ ] Espace Bitcoin : vérifier affichage du message de redirection
- [ ] Autres produits (SCPI, Livret, etc.) : vérifier que la section générique est inchangée
- [ ] Ajouter un snapshot Bitcoin depuis le dashboard et vérifier la persistance
- [ ] Tester offline (sans prix live) : métriques P&L affichent "—", badge OFFLINE visible

https://claude.ai/code/session_01HHvuqbyfYgPmmA2WoY9Hi4