### PR TITLE
feat: FR/EN i18n support + emoji cleanup (issue #3)

### DIFF
--- a/finance_tracker/i18n/__init__.py
+++ b/finance_tracker/i18n/__init__.py
@@ -1,0 +1,32 @@
+"""Internationalisation helpers for Finance Tracker."""
+
+import streamlit as st
+
+from finance_tracker.i18n import fr, en
+
+_LANGS: dict[str, dict[str, str]] = {
+    "fr": fr.STRINGS,
+    "en": en.STRINGS,
+}
+
+SUPPORTED_LANGS = list(_LANGS.keys())
+
+
+def detect_language() -> str:
+    """Detect the browser's preferred language from the Accept-Language header."""
+    try:
+        accept_lang: str = st.context.headers.get("Accept-Language", "fr")
+        return "en" if accept_lang.lower().startswith("en") else "fr"
+    except Exception:
+        return "fr"
+
+
+def t(key: str) -> str:
+    """Return the UI string for *key* in the currently active language.
+
+    Falls back to French if the key is missing in the active language,
+    and returns the key itself as a last resort.
+    """
+    lang = st.session_state.get("lang", "fr")
+    strings = _LANGS.get(lang, fr.STRINGS)
+    return strings.get(key, fr.STRINGS.get(key, key))

--- a/finance_tracker/i18n/en.py
+++ b/finance_tracker/i18n/en.py
@@ -1,0 +1,338 @@
+"""English UI strings."""
+
+STRINGS: dict[str, str] = {
+    # ── Navigation ─────────────────────────────────────────────────────────────
+    "nav.documentation": "📖 Documentation",
+    "nav.dashboard": "📊 Dashboard",
+    "nav.simulation": "🔮 Long-Term Simulation",
+    "nav.products": "🏷️ My Products",
+    "nav.transactions": "💸 My Transactions",
+    "nav.valuations": "📈 My Valuations",
+    "nav.bitcoin": "₿ Bitcoin Space",
+
+    # ── App / Sidebar ───────────────────────────────────────────────────────────
+    "app.lang_selector": "🌐 Language / Langue",
+    "app.db_section": "Data Management",
+    "app.import_label": "Import your backup (.db)",
+    "app.create_portfolio_btn": "Create a new portfolio",
+    "app.db_loaded_msg": "Database loaded!",
+    "app.db_init_with_products": "✅ Database initialised with {n} default products",
+    "app.db_init": "✅ Database initialised",
+    "app.export_btn": "📥 Save database (PC)",
+    "app.no_db_warning": "Please import or create a database to get started.",
+    "app.nav_label": "Navigation",
+    "app.doc_link_btn": "📖 Documentation (README)",
+    "app.donate_btn": "☕ Buy me a Bitcoffee",
+    "app.sidebar_version": "Finance Tracker v1.0.0",
+    "app.sidebar_description": "Portfolio tracking tool with support for SCPI, Bitcoin, savings and more.",
+
+    # ── Dashboard ───────────────────────────────────────────────────────────────
+    "dashboard.title": "Dashboard",
+    "dashboard.caption": "Global overview and performance of your investment portfolio.",
+    "dashboard.load_error": "Unable to load portfolio: {e}",
+    "dashboard.section_overview": "Overview",
+    "dashboard.metric_total_value": "Total Value",
+    "dashboard.metric_total_invested": "Total Invested",
+    "dashboard.metric_gains": "Gains",
+    "dashboard.metric_cash": "Available Cash",
+    "dashboard.section_allocation": "Portfolio Allocation",
+    "dashboard.empty_portfolio": "Your portfolio is empty. Add valuations in the corresponding tab.",
+    "dashboard.section_detail": "Per-product detail",
+    "dashboard.section_exports": "Exports & Reports",
+    "dashboard.prepare_pdf": "Prepare PDF report",
+    "dashboard.generating_pdf": "⏳ Generating PDF report...",
+    "dashboard.download_pdf": "⬇️ Download PDF",
+    "dashboard.pdf_filename": "portfolio_report.pdf",
+    "dashboard.prepare_json": "Prepare JSON export",
+    "dashboard.generating_json": "⏳ Structuring data...",
+    "dashboard.download_json": "⬇️ Download JSON",
+    "dashboard.json_filename": "dashboard_data.json",
+    "dashboard.refresh_exports": "Refresh export data",
+    "dashboard.error": "❌ Error: {e}",
+    # Bitcoin expander
+    "dashboard.btc_refresh_btn": "Refresh price",
+    "dashboard.btc_connecting": "Connecting to APIs...",
+    "dashboard.btc_offline": "**Offline** — Network unreachable. Enter the price manually below.",
+    "dashboard.btc_metric_value": "Current value",
+    "dashboard.btc_metric_qty": "Quantity",
+    "dashboard.btc_metric_pru": "Avg. cost",
+    "dashboard.btc_metric_pnl": "Unrealised P&L",
+    "dashboard.btc_price_history": "Price history (snapshots)",
+    "dashboard.btc_new_snapshot": "New Snapshot",
+    "dashboard.btc_date_label": "Date",
+    "dashboard.btc_full_price_label": "Price of one full BTC (EUR)",
+    "dashboard.btc_qty_label": "Quantity (in Satoshis)",
+    "dashboard.btc_qty_help": "1 BTC = 100,000,000 Sats",
+    "dashboard.btc_computed_value": "Computed value: **{v}**",
+    "dashboard.btc_save_snapshot": "Save snapshot",
+    "dashboard.btc_qty_error": "Quantity (in sats) and price must both be > 0.",
+    "dashboard.btc_snapshot_saved": "✅ Snapshot saved — Value: {v}",
+    "dashboard.btc_error": "❌ Error: {e}",
+    # Table columns
+    "dashboard.col_date": "Date",
+    "dashboard.col_btc_price": "BTC Price (€)",
+    "dashboard.col_sats": "Satoshis",
+    "dashboard.col_total_value": "Total value (€)",
+    # Allocation chart
+    "dashboard.chart_weight_pct": "Weight (%)",
+    "dashboard.chart_product": "Product",
+
+    # ── Simulation ─────────────────────────────────────────────────────────────
+    "simulation.title": "Long-Term Simulation",
+    "simulation.no_product_warning": "Add at least one product in 'Add Products' before running a simulation.",
+    "simulation.section_global_params": "Global parameters",
+    "simulation.param_duration": "Duration (years)",
+    "simulation.param_income": "Gross annual income Y (€)",
+    "simulation.param_income_growth": "Income growth / year (%)",
+    "simulation.param_living_costs": "Annual living costs (€)",
+    "simulation.param_initial_tax": "Tax due Y-1 payable in year 1 (€)",
+    "simulation.section_tax": "Taxation (progressive brackets)",
+    "simulation.tax_caption": "Annual brackets — leave `up_to` empty for the last bracket.",
+    "simulation.std_deduction": "Standard deduction (%)",
+    "simulation.section_per": "PER — Deductible cap",
+    "simulation.per_rate": "% of prior-year income",
+    "simulation.per_min": "Minimum PER cap (€/year)",
+    "simulation.per_max": "Maximum PER cap (€/year, 0 = unlimited)",
+    "simulation.section_product_params": "Per-product parameters",
+    "simulation.product_params_caption": "Only relevant parameters are shown based on the category defined above.",
+    "simulation.scpi_caption": "For a SCPI, contributions are defined via **'Shares bought / year'** below.",
+    "simulation.cash_required_error": "⚠️ At least one product of category 'cash' is required.",
+    "simulation.submit_hint": "Submit the form to run the simulation.",
+    "simulation.section_summary": "Final summary",
+    "simulation.metric_final_value": "Final value",
+    "simulation.metric_real_value": "Real value (inflation-adjusted)",
+    "simulation.metric_invested": "Total invested (excl. cash)",
+    "simulation.metric_tax_due": "Tax due Y payable in Y+1",
+    "simulation.section_tables": "Data tables",
+    "simulation.tab_by_period": "By period",
+    "simulation.tab_by_product": "By product (long)",
+    "simulation.section_charts": "Charts",
+    "simulation.section_exports": "Exports",
+    "simulation.prepare_pdf": "Prepare PDF report",
+    "simulation.section_inflation": "Inflation profile",
+    "simulation.section_categories": "Product categories",
+    "simulation.pdf_error": "Error generating PDF: {e}",
+
+    # ── Products ────────────────────────────────────────────────────────────────
+    "products.title": "My Products",
+    "products.caption": "Create, edit and delete your products. (Deletion may fail if transactions/valuations exist.)",
+    "products.add_expander": "Add a product",
+    "products.field_name": "Name *",
+    "products.field_type": "Type",
+    "products.field_unit": "Unit",
+    "products.field_risk": "Risk level (optional)",
+    "products.field_description": "Description",
+    "products.field_fees": "Fees",
+    "products.field_tax": "Taxation",
+    "products.create_btn": "Create",
+    "products.name_required": "Name is required.",
+    "products.name_duplicate": "A product named '{name}' already exists.",
+    "products.created_success": "✅ Product created.",
+    "products.error": "❌ Error: {e}",
+    "products.empty": "No products yet.",
+    "products.list_title": "Products (editable)",
+    "products.col_id": "ID",
+    "products.col_name": "Name",
+    "products.col_type": "Type",
+    "products.col_unit": "Unit",
+    "products.col_risk": "Risk",
+    "products.col_description": "Description",
+    "products.col_fees": "Fees",
+    "products.col_tax": "Taxation",
+    "products.col_created_at": "Created",
+    "products.col_delete": "🗑️ Delete",
+    "products.advanced_delete_expander": "Deletion tools (advanced)",
+    "products.advanced_delete_help": "If product deletion fails, delete associated transactions/valuations first.",
+    "products.advanced_delete_tip": "Tip: use the Transactions / Valuations page, filter by product, check 🗑️ and apply.",
+    "products.apply_btn": "Apply changes",
+    "products.name_empty_error": "All products (not deleted) must have a name.",
+    "products.name_unique_error": "Product names must be unique (at least among non-deleted rows).",
+    "products.applied_success": "✅ Changes applied.",
+    "products.reload_btn": "Reload from DB",
+
+    # ── Transactions ────────────────────────────────────────────────────────────
+    "transactions.title": "My Transactions",
+    "transactions.caption": "Add, edit and delete directly from the list.",
+    "transactions.no_products": "No products. Create a product first before adding transactions.",
+    "transactions.add_expander": "Add a transaction",
+    "transactions.field_product": "Product",
+    "transactions.field_type": "Type",
+    "transactions.field_date": "Date",
+    "transactions.field_amount": "Amount EUR (optional)",
+    "transactions.field_qty_sats": "Quantity (in Satoshis)",
+    "transactions.field_qty_units": "Quantity (Shares / Units)",
+    "transactions.field_qty_help_btc": "Reminder: 1 BTC = 100,000,000 Sats",
+    "transactions.field_note": "Note",
+    "transactions.add_btn": "Add",
+    "transactions.added_success": "✅ Transaction added.",
+    "transactions.error": "❌ Error: {e}",
+    "transactions.filter_product": "Filter product",
+    "transactions.filter_type": "Filter type",
+    "transactions.filter_all": "All",
+    "transactions.sort_label": "Sort",
+    "transactions.sort_date_desc": "Date descending",
+    "transactions.sort_date_asc": "Date ascending",
+    "transactions.sort_id_desc": "ID descending",
+    "transactions.empty_filter": "No transactions for this filter.",
+    "transactions.list_title": "History (editable)",
+    "transactions.btc_qty_info": "ℹ️ Bitcoin quantities are displayed and stored in **Satoshis** (integers). Other products use standard units.",
+    "transactions.col_id": "ID",
+    "transactions.col_date": "Date",
+    "transactions.col_product": "Product",
+    "transactions.col_type": "Type",
+    "transactions.col_amount": "Amount EUR",
+    "transactions.col_qty": "Quantity (Sats or Units)",
+    "transactions.col_note": "Note",
+    "transactions.col_delete": "🗑️ Delete",
+    "transactions.apply_btn": "Apply changes",
+    "transactions.invalid_product": "Invalid product: {name}",
+    "transactions.applied_success": "✅ Changes applied.",
+    "transactions.reload_btn": "Reload from DB",
+
+    # ── Valuations ──────────────────────────────────────────────────────────────
+    "valuations.title": "My Valuations",
+    "valuations.caption": "Value snapshots: add, edit and delete from a single table.",
+    "valuations.no_products": "No products. Create a product before adding valuations.",
+    "valuations.add_expander": "Add a valuation",
+    "valuations.field_product": "Product",
+    "valuations.field_date": "Date",
+    "valuations.field_total": "Total value EUR",
+    "valuations.field_unit_price_btc": "Price of one full BTC (EUR)",
+    "valuations.field_unit_price": "Unit price (EUR, optional)",
+    "valuations.add_btn": "Add",
+    "valuations.total_positive_error": "Total value must be > 0.",
+    "valuations.added_success": "✅ Valuation added.",
+    "valuations.error": "❌ Error: {e}",
+    "valuations.filter_product": "Filter product",
+    "valuations.filter_all": "All",
+    "valuations.sort_label": "Sort",
+    "valuations.sort_date_desc": "Date descending",
+    "valuations.sort_date_asc": "Date ascending",
+    "valuations.sort_id_desc": "ID descending",
+    "valuations.empty_filter": "No valuations for this filter.",
+    "valuations.list_title": "History (editable)",
+    "valuations.col_id": "ID",
+    "valuations.col_date": "Date",
+    "valuations.col_product": "Product",
+    "valuations.col_total": "Total value EUR",
+    "valuations.col_unit_price": "Unit price EUR",
+    "valuations.col_delete": "🗑️ Delete",
+    "valuations.apply_btn": "Apply changes",
+    "valuations.invalid_product": "Invalid product: {name}",
+    "valuations.total_positive_update_error": "Total value must be > 0.",
+    "valuations.applied_success": "✅ Changes applied.",
+    "valuations.reload_btn": "Reload from DB",
+
+    # ── Bitcoin ─────────────────────────────────────────────────────────────────
+    "bitcoin.title": "₿ Bitcoin Space",
+    "bitcoin.redirect_info": (
+        "**This page has been merged into the Dashboard.**\n\n"
+        "All Bitcoin features are now available from "
+        "**📊 Dashboard → Per-product detail → Bitcoin**:\n\n"
+        "- Live BTC/EUR price with LIVE / OFFLINE badge\n"
+        "- Quantity in Satoshis\n"
+        "- Avg. cost and unrealised P&L\n"
+        "- Price history (snapshots)\n"
+        "- New snapshot form\n"
+        "- Recent snapshots table"
+    ),
+    "bitcoin.redirect_link": "Head to **📊 Dashboard** to access your Bitcoin space.",
+
+    # ── Documentation ───────────────────────────────────────────────────────────
+    "documentation.title": "Documentation",
+    "documentation.subtitle": "Complete guide to using and understanding Finance Tracker",
+    "documentation.tab_home": "Home",
+    "documentation.tab_concepts": "Concepts",
+    "documentation.tab_calculs": "Calculations",
+    "documentation.tab_interface": "Web Interface",
+    "documentation.tab_database": "Database",
+    "documentation.tab_install": "Installation",
+    "documentation.tab_help": "Help",
+    # Home tab
+    "documentation.home_title": "Welcome to Finance Tracker",
+    "documentation.home_intro": (
+        "**Finance Tracker** is a comprehensive investment portfolio management application,\n"
+        "designed for privacy-conscious investors."
+    ),
+    "documentation.home_features_title": "Key Features",
+    "documentation.home_feature_tracking": "**📊 Complete Tracking**\n- Multi-asset portfolio\n- SCPI, Bitcoin, Savings\n- Life insurance, PER",
+    "documentation.home_feature_analysis": "**📈 Advanced Analytics**\n- MWRR performance\n- Compound interest\n- Long-term projections",
+    "documentation.home_feature_privacy": "**🔒 Privacy**\n- Local data only\n- No cloud required\n- Easy export/import",
+    "documentation.home_quickstart_title": "Quick Start",
+    "documentation.home_quickstart_table": (
+        "| Step | Action | Page |\n"
+        "|------|--------|------|\n"
+        "| 1 | Create your products | 🏷️ **My Products** |\n"
+        "| 2 | Add transactions | 💸 **My Transactions** |\n"
+        "| 3 | Update valuations | 📈 **My Valuations** |\n"
+        "| 4 | View the dashboard | 📊 **Dashboard** |"
+    ),
+    "documentation.home_explore_title": "Explore the Documentation",
+    "documentation.home_explore_text": "Use the **tabs above** to access the different documentation sections.",
+    "documentation.home_tip": (
+        "**Tip:** Start with the **Concepts** tab to understand the 3 pillars\n"
+        "of the system (Products, Transactions, Valuations) before using the app."
+    ),
+    # Concepts tab
+    "documentation.concepts_title": "Fundamental Concepts",
+    "documentation.concepts_intro": (
+        "Finance Tracker is built on **three essential pillars**. Understanding these concepts\n"
+        "is the key to using the application effectively."
+    ),
+    "documentation.concepts_products_title": "1. Products",
+    "documentation.concepts_transactions_title": "2. Transactions (Movements)",
+    "documentation.concepts_valuations_title": "3. Valuations (Snapshots)",
+    "documentation.full_doc_link": "**[Read full documentation: {title}]({url})**",
+    "documentation.expand_full_doc": "View full document",
+    # Calculs tab
+    "documentation.calculs_title": "Formulas & Calculations",
+    "documentation.calculs_intro": (
+        "All the mathematical formulas used by Finance Tracker to compute\n"
+        "performance, gains and projections."
+    ),
+    "documentation.calculs_key_metrics": "Key Indicators",
+    "documentation.calculs_compound": "Compound Interest",
+    "documentation.calculs_bitcoin_title": "₿ Special Case: Bitcoin",
+    # Interface tab
+    "documentation.interface_title": "Web Interface Guide",
+    "documentation.interface_intro": "Complete page-by-page guide to the Streamlit interface.",
+    "documentation.interface_architecture": "Application Architecture",
+    "documentation.interface_workflow": "Recommended Workflow",
+    "documentation.interface_tx_types": "Transaction Types",
+    # Installation tab
+    "documentation.install_title": "Installation & Development",
+    "documentation.install_intro": "Guides for installing, configuring and contributing to the project.",
+    "documentation.install_quickstart": "Quick Start (Developer)",
+    "documentation.install_architecture": "Project Architecture",
+    "documentation.install_dev_docs": "Developer Documentation",
+    # Database tab
+    "documentation.database_title": "Database Structure",
+    "documentation.database_intro": (
+        "Finance Tracker uses **SQLite** with **SQLModel** for data persistence."
+    ),
+    "documentation.database_tables": "Main Tables",
+    "documentation.database_relations": "Relations",
+    # Help tab
+    "documentation.help_title": "Help & Support",
+    "documentation.help_faq_title": "FAQ",
+    "documentation.help_resources_title": "Resources",
+    "documentation.help_resources_official": "**Official Links**",
+    "documentation.help_resources_web": "[Web Application](https://finance-tracker-skohscripts.streamlit.app/)",
+    "documentation.help_resources_github": "[GitHub](https://github.com/SKOHscripts/finance-tracker)",
+    "documentation.help_resources_support": "**Support**",
+    "documentation.help_resources_bug": "[Report a bug](https://github.com/SKOHscripts/finance-tracker/issues)",
+    "documentation.help_resources_feature": "[Suggest a feature](https://github.com/SKOHscripts/finance-tracker/discussions)",
+    "documentation.help_resources_docs": "**Documentation**",
+    "documentation.help_resources_readme": "[Full README]({url}/README.md)",
+    "documentation.help_resources_roadmap": "[Roadmap]({url}/ROADMAP.md)",
+    "documentation.help_tips_title": "Usage Tips",
+    "documentation.help_tips": (
+        "**Tip #1:** Start by reading **Concepts** to understand the 3 pillars of the system.\n\n"
+        "**Tip #2:** Update your **📈 Valuations** regularly (monthly minimum).\n\n"
+        "**Tip #3:** Use the **🔮 Simulator** to plan your future investments.\n\n"
+        "**Tip #4:** Back up your database regularly via the sidebar."
+    ),
+    "documentation.card_read_more": "Read full documentation →",
+    "documentation.file_not_found": "⚠️ File {filename} not found.",
+    "documentation.file_load_error": "❌ Error loading file: {error}",
+}

--- a/finance_tracker/i18n/fr.py
+++ b/finance_tracker/i18n/fr.py
@@ -1,0 +1,338 @@
+"""French UI strings."""
+
+STRINGS: dict[str, str] = {
+    # ── Navigation ─────────────────────────────────────────────────────────────
+    "nav.documentation": "📖 Documentation",
+    "nav.dashboard": "📊 Tableau de Bord",
+    "nav.simulation": "🔮 Simulation Long Terme",
+    "nav.products": "🏷️ Mes Produits",
+    "nav.transactions": "💸 Mes Transactions",
+    "nav.valuations": "📈 Mes Valorisations",
+    "nav.bitcoin": "₿ Espace Bitcoin",
+
+    # ── App / Sidebar ───────────────────────────────────────────────────────────
+    "app.lang_selector": "🌐 Language / Langue",
+    "app.db_section": "Gestion des Données",
+    "app.import_label": "Importer votre sauvegarde (.db)",
+    "app.create_portfolio_btn": "Créer un nouveau portefeuille",
+    "app.db_loaded_msg": "Base de données chargée !",
+    "app.db_init_with_products": "✅ Base initialisée avec {n} produits par défaut",
+    "app.db_init": "✅ Base initialisée",
+    "app.export_btn": "📥 Sauvegarder la base (PC)",
+    "app.no_db_warning": "Veuillez importer ou créer une base pour commencer.",
+    "app.nav_label": "Navigation",
+    "app.doc_link_btn": "📖 Documentation (README)",
+    "app.donate_btn": "☕ Buy me a Bitcoffee",
+    "app.sidebar_version": "Finance Tracker v1.0.0",
+    "app.sidebar_description": "Outil de suivi de portefeuille avec support SCPI, Bitcoin, épargne et plus.",
+
+    # ── Dashboard ───────────────────────────────────────────────────────────────
+    "dashboard.title": "Tableau de bord",
+    "dashboard.caption": "Aperçu global et performances de votre portefeuille d'investissement.",
+    "dashboard.load_error": "Impossible de charger le portefeuille : {e}",
+    "dashboard.section_overview": "Vue d'ensemble",
+    "dashboard.metric_total_value": "Valeur Totale",
+    "dashboard.metric_total_invested": "Total Investi",
+    "dashboard.metric_gains": "Plus-values",
+    "dashboard.metric_cash": "Cash disponible",
+    "dashboard.section_allocation": "Répartition du portefeuille",
+    "dashboard.empty_portfolio": "Votre portefeuille est vide. Ajoutez des valorisations dans l'onglet correspondant.",
+    "dashboard.section_detail": "Détail par produit",
+    "dashboard.section_exports": "Exports & Rapports",
+    "dashboard.prepare_pdf": "Préparer le rapport PDF",
+    "dashboard.generating_pdf": "⏳ Génération du rapport PDF...",
+    "dashboard.download_pdf": "⬇️ Télécharger le PDF",
+    "dashboard.pdf_filename": "rapport_portefeuille.pdf",
+    "dashboard.prepare_json": "Préparer l'export JSON",
+    "dashboard.generating_json": "⏳ Structuration des données...",
+    "dashboard.download_json": "⬇️ Télécharger le JSON",
+    "dashboard.json_filename": "dashboard_data.json",
+    "dashboard.refresh_exports": "Rafraîchir les données d'export",
+    "dashboard.error": "❌ Erreur : {e}",
+    # Bitcoin expander
+    "dashboard.btc_refresh_btn": "Actualiser le cours",
+    "dashboard.btc_connecting": "Connexion aux APIs...",
+    "dashboard.btc_offline": "**Hors ligne** — Réseau inaccessible. Saisissez le prix manuellement ci-dessous.",
+    "dashboard.btc_metric_value": "Valeur actuelle",
+    "dashboard.btc_metric_qty": "Quantité",
+    "dashboard.btc_metric_pru": "PRU",
+    "dashboard.btc_metric_pnl": "P&L Latente",
+    "dashboard.btc_price_history": "Historique des prix (snapshots)",
+    "dashboard.btc_new_snapshot": "Nouveau Snapshot",
+    "dashboard.btc_date_label": "Date",
+    "dashboard.btc_full_price_label": "Prix d'un BTC plein (EUR)",
+    "dashboard.btc_qty_label": "Quantité (en Satoshis)",
+    "dashboard.btc_qty_help": "1 BTC = 100 000 000 Sats",
+    "dashboard.btc_computed_value": "Valeur calculée : **{v}**",
+    "dashboard.btc_save_snapshot": "Enregistrer le snapshot",
+    "dashboard.btc_qty_error": "La quantité (en sats) et le prix doivent être > 0.",
+    "dashboard.btc_snapshot_saved": "✅ Snapshot enregistré — Valeur : {v}",
+    "dashboard.btc_error": "❌ Erreur : {e}",
+    # Table columns
+    "dashboard.col_date": "Date",
+    "dashboard.col_btc_price": "Prix BTC (€)",
+    "dashboard.col_sats": "Satoshis",
+    "dashboard.col_total_value": "Valeur totale (€)",
+    # Allocation chart
+    "dashboard.chart_weight_pct": "Poids (%)",
+    "dashboard.chart_product": "Produit",
+
+    # ── Simulation ─────────────────────────────────────────────────────────────
+    "simulation.title": "Simulation Long Terme",
+    "simulation.no_product_warning": "Ajoute au moins un produit dans 'Ajouter Produits' avant de simuler.",
+    "simulation.section_global_params": "Paramètres globaux",
+    "simulation.param_duration": "Durée (années)",
+    "simulation.param_income": "Revenu brut annuel N (€)",
+    "simulation.param_income_growth": "Augmentation revenu / an (%)",
+    "simulation.param_living_costs": "Dépenses annuelles (€)",
+    "simulation.param_initial_tax": "Impôt dû N-1 à payer en année 1 (€)",
+    "simulation.section_tax": "Fiscalité (barème progressif)",
+    "simulation.tax_caption": "Tranches annuelles — laisse `up_to` vide pour la dernière tranche.",
+    "simulation.std_deduction": "Abattement forfaitaire (%)",
+    "simulation.section_per": "PER — Plafond déductible",
+    "simulation.per_rate": "% du revenu N-1",
+    "simulation.per_min": "Plafond PER minimum (€/an)",
+    "simulation.per_max": "Plafond PER maximum (€/an, 0 = illimité)",
+    "simulation.section_product_params": "Paramètres par produit",
+    "simulation.product_params_caption": "Seuls les paramètres pertinents s'affichent selon la catégorie définie ci-dessus.",
+    "simulation.scpi_caption": "Pour une SCPI, les apports sont définis via **'Parts achetées / an'** ci-dessous.",
+    "simulation.cash_required_error": "⚠️ Il faut au moins un produit de catégorie 'cash'.",
+    "simulation.submit_hint": "Soumets le formulaire pour lancer la simulation.",
+    "simulation.section_summary": "Résumé final",
+    "simulation.metric_final_value": "Valeur finale",
+    "simulation.metric_real_value": "Valeur réelle (inflation)",
+    "simulation.metric_invested": "Investi cumulé (hors cash)",
+    "simulation.metric_tax_due": "Impôt dû N à payer N+1",
+    "simulation.section_tables": "Tableaux de données",
+    "simulation.tab_by_period": "Par période",
+    "simulation.tab_by_product": "Par produit (long)",
+    "simulation.section_charts": "Graphiques",
+    "simulation.section_exports": "Exports",
+    "simulation.prepare_pdf": "Préparer le rapport PDF",
+    "simulation.section_inflation": "Profil d'inflation",
+    "simulation.section_categories": "Catégories des produits",
+    "simulation.pdf_error": "Erreur lors de la génération du PDF : {e}",
+
+    # ── Products ────────────────────────────────────────────────────────────────
+    "products.title": "Mes Produits",
+    "products.caption": "Créez, éditez et supprimez vos produits. (La suppression peut échouer si des transactions/valorisations existent.)",
+    "products.add_expander": "Ajouter un produit",
+    "products.field_name": "Nom *",
+    "products.field_type": "Type",
+    "products.field_unit": "Unité",
+    "products.field_risk": "Niveau de risque (optionnel)",
+    "products.field_description": "Description",
+    "products.field_fees": "Frais",
+    "products.field_tax": "Fiscalité",
+    "products.create_btn": "Créer",
+    "products.name_required": "Le nom est obligatoire.",
+    "products.name_duplicate": "Un produit nommé '{name}' existe déjà.",
+    "products.created_success": "✅ Produit créé.",
+    "products.error": "❌ Erreur : {e}",
+    "products.empty": "Aucun produit pour l'instant.",
+    "products.list_title": "Liste des produits (éditable)",
+    "products.col_id": "ID",
+    "products.col_name": "Nom",
+    "products.col_type": "Type",
+    "products.col_unit": "Unité",
+    "products.col_risk": "Risque",
+    "products.col_description": "Description",
+    "products.col_fees": "Frais",
+    "products.col_tax": "Fiscalité",
+    "products.col_created_at": "Créé le",
+    "products.col_delete": "🗑️ Supprimer",
+    "products.advanced_delete_expander": "Outils suppression (avancé)",
+    "products.advanced_delete_help": "Si une suppression de produit échoue, supprimez d'abord les transactions/valorisations associées.",
+    "products.advanced_delete_tip": "Astuce : utilisez la page Transactions / Valorisations, filtrez par produit, cochez 🗑️ puis appliquez.",
+    "products.apply_btn": "Appliquer les changements",
+    "products.name_empty_error": "Tous les produits (non supprimés) doivent avoir un nom.",
+    "products.name_unique_error": "Les noms de produits doivent être uniques (au moins parmi les lignes non supprimées).",
+    "products.applied_success": "✅ Changements appliqués.",
+    "products.reload_btn": "Recharger depuis la DB",
+
+    # ── Transactions ────────────────────────────────────────────────────────────
+    "transactions.title": "Mes Transactions",
+    "transactions.caption": "Ajout, modification et suppression directement depuis la liste.",
+    "transactions.no_products": "Aucun produit. Créez d'abord un produit pour pouvoir ajouter des transactions.",
+    "transactions.add_expander": "Ajouter une transaction",
+    "transactions.field_product": "Produit",
+    "transactions.field_type": "Type",
+    "transactions.field_date": "Date",
+    "transactions.field_amount": "Montant EUR (optionnel)",
+    "transactions.field_qty_sats": "Quantité (en Satoshis)",
+    "transactions.field_qty_units": "Quantité (Parts / Unités)",
+    "transactions.field_qty_help_btc": "Rappel: 1 BTC = 100 000 000 Sats",
+    "transactions.field_note": "Note",
+    "transactions.add_btn": "Ajouter",
+    "transactions.added_success": "✅ Transaction ajoutée.",
+    "transactions.error": "❌ Erreur : {e}",
+    "transactions.filter_product": "Filtrer produit",
+    "transactions.filter_type": "Filtrer type",
+    "transactions.filter_all": "Tous",
+    "transactions.sort_label": "Tri",
+    "transactions.sort_date_desc": "Date décroissante",
+    "transactions.sort_date_asc": "Date croissante",
+    "transactions.sort_id_desc": "ID décroissant",
+    "transactions.empty_filter": "Aucune transaction pour ce filtre.",
+    "transactions.list_title": "Historique (éditable)",
+    "transactions.btc_qty_info": "ℹ️ Les quantités concernant Bitcoin sont affichées et enregistrées en **Satoshis** (nombres entiers). Les autres produits restent en unités standards.",
+    "transactions.col_id": "ID",
+    "transactions.col_date": "Date",
+    "transactions.col_product": "Produit",
+    "transactions.col_type": "Type",
+    "transactions.col_amount": "Montant EUR",
+    "transactions.col_qty": "Quantité (Sats ou Unités)",
+    "transactions.col_note": "Note",
+    "transactions.col_delete": "🗑️ Supprimer",
+    "transactions.apply_btn": "Appliquer les changements",
+    "transactions.invalid_product": "Produit invalide: {name}",
+    "transactions.applied_success": "✅ Changements appliqués.",
+    "transactions.reload_btn": "Recharger depuis la DB",
+
+    # ── Valuations ──────────────────────────────────────────────────────────────
+    "valuations.title": "Mes Valorisations",
+    "valuations.caption": "Snapshots de valeur : ajout, édition et suppression depuis une table unique.",
+    "valuations.no_products": "Aucun produit. Créez un produit avant d'ajouter des valorisations.",
+    "valuations.add_expander": "Ajouter une valorisation",
+    "valuations.field_product": "Produit",
+    "valuations.field_date": "Date",
+    "valuations.field_total": "Valeur totale EUR",
+    "valuations.field_unit_price_btc": "Prix d'un BTC plein (EUR)",
+    "valuations.field_unit_price": "Prix unitaire (EUR, optionnel)",
+    "valuations.add_btn": "Ajouter",
+    "valuations.total_positive_error": "La valeur totale doit être > 0.",
+    "valuations.added_success": "✅ Valorisation ajoutée.",
+    "valuations.error": "❌ Erreur : {e}",
+    "valuations.filter_product": "Filtrer produit",
+    "valuations.filter_all": "Tous",
+    "valuations.sort_label": "Tri",
+    "valuations.sort_date_desc": "Date décroissante",
+    "valuations.sort_date_asc": "Date croissante",
+    "valuations.sort_id_desc": "ID décroissant",
+    "valuations.empty_filter": "Aucune valorisation pour ce filtre.",
+    "valuations.list_title": "Historique (éditable)",
+    "valuations.col_id": "ID",
+    "valuations.col_date": "Date",
+    "valuations.col_product": "Produit",
+    "valuations.col_total": "Valeur totale EUR",
+    "valuations.col_unit_price": "Prix unitaire EUR",
+    "valuations.col_delete": "🗑️ Supprimer",
+    "valuations.apply_btn": "Appliquer les changements",
+    "valuations.invalid_product": "Produit invalide: {name}",
+    "valuations.total_positive_update_error": "La valeur totale doit être > 0.",
+    "valuations.applied_success": "✅ Changements appliqués.",
+    "valuations.reload_btn": "Recharger depuis la DB",
+
+    # ── Bitcoin ─────────────────────────────────────────────────────────────────
+    "bitcoin.title": "₿ Espace Bitcoin",
+    "bitcoin.redirect_info": (
+        "**Cette page a été fusionnée dans le Tableau de Bord.**\n\n"
+        "Toutes les fonctionnalités Bitcoin sont désormais accessibles depuis "
+        "**📊 Tableau de Bord → Détail par produit → Bitcoin** :\n\n"
+        "- Cours live BTC/EUR avec badge LIVE / OFFLINE\n"
+        "- Quantité en Satoshis\n"
+        "- PRU et P&L latente\n"
+        "- Historique des prix (snapshots)\n"
+        "- Formulaire de nouveau snapshot\n"
+        "- Tableau des derniers snapshots"
+    ),
+    "bitcoin.redirect_link": "Rendez-vous dans **📊 Tableau de Bord** pour accéder à votre espace Bitcoin.",
+
+    # ── Documentation ───────────────────────────────────────────────────────────
+    "documentation.title": "Documentation",
+    "documentation.subtitle": "Guide complet pour utiliser et comprendre Finance Tracker",
+    "documentation.tab_home": "Accueil",
+    "documentation.tab_concepts": "Concepts",
+    "documentation.tab_calculs": "Calculs",
+    "documentation.tab_interface": "Interface Web",
+    "documentation.tab_database": "Base de Données",
+    "documentation.tab_install": "Installation",
+    "documentation.tab_help": "Aide",
+    # Home tab
+    "documentation.home_title": "Bienvenue dans Finance Tracker",
+    "documentation.home_intro": (
+        "**Finance Tracker** est une application complète de gestion de portefeuille d'investissement,\n"
+        "conçue pour les investisseurs francophones soucieux de leur vie privée."
+    ),
+    "documentation.home_features_title": "Fonctionnalités Principales",
+    "documentation.home_feature_tracking": "**📊 Suivi Complet**\n- Portefeuille multi-actifs\n- SCPI, Bitcoin, Livrets\n- Assurance-vie, PER",
+    "documentation.home_feature_analysis": "**📈 Analyses Avancées**\n- Performance MWRR\n- Intérêts composés\n- Projections long terme",
+    "documentation.home_feature_privacy": "**🔒 Vie Privée**\n- Données locales\n- Aucun cloud requis\n- Export/Import facile",
+    "documentation.home_quickstart_title": "Démarrage Rapide",
+    "documentation.home_quickstart_table": (
+        "| Étape | Action | Page |\n"
+        "|-------|--------|------|\n"
+        "| 1 | Créer vos produits | 🏷️ **Mes Produits** |\n"
+        "| 2 | Ajouter des transactions | 💸 **Mes Transactions** |\n"
+        "| 3 | Mettre à jour les valorisations | 📈 **Mes Valorisations** |\n"
+        "| 4 | Consulter le tableau de bord | 📊 **Tableau de Bord** |"
+    ),
+    "documentation.home_explore_title": "Explorer la Documentation",
+    "documentation.home_explore_text": "Utilisez les **onglets ci-dessus** pour accéder aux différentes sections de documentation.",
+    "documentation.home_tip": (
+        "**Astuce :** Commencez par l'onglet **Concepts** pour comprendre les 3 piliers\n"
+        "du système (Produits, Transactions, Valorisations) avant d'utiliser l'application."
+    ),
+    # Concepts tab
+    "documentation.concepts_title": "Concepts Fondamentaux",
+    "documentation.concepts_intro": (
+        "Finance Tracker repose sur **trois piliers** essentiels. Comprendre ces concepts\n"
+        "est la clé pour utiliser efficacement l'application."
+    ),
+    "documentation.concepts_products_title": "1. Produits (Products)",
+    "documentation.concepts_transactions_title": "2. Transactions (Mouvements)",
+    "documentation.concepts_valuations_title": "3. Valorisations (Snapshots)",
+    "documentation.full_doc_link": "**[Lire la documentation complète : {title}]({url})**",
+    "documentation.expand_full_doc": "Voir le document complet",
+    # Calculs tab
+    "documentation.calculs_title": "Formules & Calculs",
+    "documentation.calculs_intro": (
+        "Toutes les formules mathématiques utilisées par Finance Tracker pour calculer\n"
+        "les performances, gains et projections."
+    ),
+    "documentation.calculs_key_metrics": "Indicateurs Clés",
+    "documentation.calculs_compound": "Intérêts Composés",
+    "documentation.calculs_bitcoin_title": "₿ Cas Spécial : Bitcoin",
+    # Interface tab
+    "documentation.interface_title": "Guide Interface Web",
+    "documentation.interface_intro": "Guide complet page par page de l'interface Streamlit.",
+    "documentation.interface_architecture": "Architecture de l'Application",
+    "documentation.interface_workflow": "Flux de Travail Recommandé",
+    "documentation.interface_tx_types": "Types de Transactions",
+    # Installation tab
+    "documentation.install_title": "Installation & Développement",
+    "documentation.install_intro": "Guides pour installer, configurer et contribuer au projet.",
+    "documentation.install_quickstart": "Démarrage Rapide (Développeur)",
+    "documentation.install_architecture": "Architecture du Projet",
+    "documentation.install_dev_docs": "Documentation Développeur",
+    # Database tab
+    "documentation.database_title": "Structure de la Base de Données",
+    "documentation.database_intro": (
+        "Finance Tracker utilise **SQLite** avec **SQLModel** pour la persistance des données."
+    ),
+    "documentation.database_tables": "Tables Principales",
+    "documentation.database_relations": "Relations",
+    # Help tab
+    "documentation.help_title": "Aide & Support",
+    "documentation.help_faq_title": "FAQ",
+    "documentation.help_resources_title": "Ressources",
+    "documentation.help_resources_official": "**Liens Officiels**",
+    "documentation.help_resources_web": "[Application Web](https://finance-tracker-skohscripts.streamlit.app/)",
+    "documentation.help_resources_github": "[GitHub](https://github.com/SKOHscripts/finance-tracker)",
+    "documentation.help_resources_support": "**Support**",
+    "documentation.help_resources_bug": "[Signaler un bug](https://github.com/SKOHscripts/finance-tracker/issues)",
+    "documentation.help_resources_feature": "[Proposer une fonctionnalité](https://github.com/SKOHscripts/finance-tracker/discussions)",
+    "documentation.help_resources_docs": "**Documentation**",
+    "documentation.help_resources_readme": "[README complet]({url}/README.md)",
+    "documentation.help_resources_roadmap": "[Roadmap]({url}/ROADMAP.md)",
+    "documentation.help_tips_title": "Conseils d'Utilisation",
+    "documentation.help_tips": (
+        "**Conseil #1 :** Commencez par lire les **Concepts** pour comprendre les 3 piliers du système.\n\n"
+        "**Conseil #2 :** Mettez à jour vos **📈 Valorisations** régulièrement (mensuellement minimum).\n\n"
+        "**Conseil #3 :** Utilisez le **🔮 Simulateur** pour planifier vos investissements futurs.\n\n"
+        "**Conseil #4 :** Sauvegardez régulièrement votre base de données via la sidebar."
+    ),
+    "documentation.card_read_more": "Lire la documentation complète →",
+    "documentation.file_not_found": "⚠️ Fichier {filename} introuvable.",
+    "documentation.file_load_error": "❌ Erreur lors du chargement du fichier: {error}",
+}

--- a/finance_tracker/web/app.py
+++ b/finance_tracker/web/app.py
@@ -16,6 +16,7 @@ from finance_tracker.web.db import get_session, get_db_path, get_engine
 from finance_tracker.web.navigation import build_pages
 from finance_tracker.repositories.sqlmodel_repo import init_db
 from finance_tracker.services.seed_service import seed_default_products
+from finance_tracker.i18n import t, detect_language, SUPPORTED_LANGS
 
 # Used for linking to GitHub documentation from the UI
 GITHUB_BASE_URL = "https://github.com/SKOHscripts/finance-tracker/blob/main"
@@ -29,6 +30,25 @@ st.set_page_config(
     initial_sidebar_state="expanded",
     )
 
+# ── Language selection ─────────────────────────────────────────────────────────
+# Detect browser preference on first load; allow manual override afterwards.
+if "lang" not in st.session_state:
+    st.session_state.lang = detect_language()
+
+lang_choice = st.sidebar.selectbox(
+    t("app.lang_selector"),
+    options=SUPPORTED_LANGS,
+    index=SUPPORTED_LANGS.index(st.session_state.lang),
+    format_func=lambda x: "Français" if x == "fr" else "English",
+    key="lang_select",
+)
+if lang_choice != st.session_state.lang:
+    st.session_state.lang = lang_choice
+    st.rerun()
+
+st.sidebar.markdown("---")
+
+# ── Logo ───────────────────────────────────────────────────────────────────────
 # Create a right-aligned title using column layout
 col1, col2 = st.columns([5, 2])
 
@@ -58,18 +78,18 @@ def render_db_manager():
     Handles importing, creating, and exporting SQLite database files for the application.
     Also seeds default products when creating a new database.
     """
-    st.sidebar.markdown("### 💾 Gestion des Données")
+    st.sidebar.markdown(f"### {t('app.db_section')}")
     db_path = get_db_path()
 
     # IMPORT
     # Allow users to restore a previously exported database file
-    uploaded_file = st.sidebar.file_uploader("Importer votre sauvegarde (.db)", type=["db", "sqlite", "sqlite3"])
+    uploaded_file = st.sidebar.file_uploader(t("app.import_label"), type=["db", "sqlite", "sqlite3"])
 
     if uploaded_file is not None and not st.session_state.get("db_loaded", False):
         with open(db_path, "wb") as f:
             f.write(uploaded_file.getbuffer())
         st.session_state.db_loaded = True
-        st.sidebar.success("Base de données chargée !")
+        st.sidebar.success(t("app.db_loaded_msg"))
         # Force Streamlit to re-run to proceed with the loaded database
         st.rerun()
 
@@ -77,7 +97,7 @@ def render_db_manager():
     # Create a fresh database if none exists
 
     if not os.path.exists(db_path):
-        if st.sidebar.button("Créer un nouveau portefeuille"):
+        if st.sidebar.button(t("app.create_portfolio_btn")):
             # Each user gets their own database instance via dynamic engine
             engine = get_engine()
             init_db(engine)
@@ -90,13 +110,13 @@ def render_db_manager():
             st.session_state.db_loaded = True
 
             if created_count > 0:
-                st.sidebar.success(f"✅ Base initialisée avec {created_count} produits par défaut")
+                st.sidebar.success(t("app.db_init_with_products").format(n=created_count))
             else:
-                st.sidebar.success("✅ Base initialisée")
+                st.sidebar.success(t("app.db_init"))
 
             st.rerun()
 
-        st.warning("Veuillez importer ou créer une base pour commencer.")
+        st.warning(t("app.no_db_warning"))
         # Stop execution here - no point loading the rest of the app without a database
         st.stop()
 
@@ -106,7 +126,7 @@ def render_db_manager():
     if os.path.exists(db_path):
         with open(db_path, "rb") as f:
             st.sidebar.download_button(
-                label="📥 Sauvegarder la base (PC)",
+                label=t("app.export_btn"),
                 data=f,
                 file_name="finance_tracker_backup.db",
                 mime="application/octet-stream"
@@ -122,23 +142,28 @@ session = get_session()
 
 st.sidebar.markdown("---")
 pages = build_pages()
-labels = [p.label for p in pages]
-selected = st.sidebar.radio("Navigation", labels)
+
+# Use stable page IDs in the radio widget so the selected page survives language changes.
+selected_id = st.sidebar.radio(
+    t("app.nav_label"),
+    options=[p.id for p in pages],
+    format_func=lambda pid: next(p.label for p in pages if p.id == pid),
+)
 st.sidebar.link_button(
-    "📖 Documentation (README)",
+    t("app.doc_link_btn"),
     f"{GITHUB_BASE_URL}/README.md",
     )
 st.sidebar.markdown("---")
 
 # donation button
 st.sidebar.link_button(
-    "☕ Buy me a Bitcoffee",
+    t("app.donate_btn"),
     "https://html-preview.github.io/?url=https://github.com/SKOHscripts/donate.github.io/blob/main/donate%2Fredirect.html"
     )
 st.sidebar.markdown("---")
 
-st.sidebar.info("**Finance Tracker v1.0.0**\n\nOutil de suivi de portefeuille avec support SCPI, Bitcoin, épargne et plus.")
+st.sidebar.info(f"**{t('app.sidebar_version')}**\n\n{t('app.sidebar_description')}")
 
 # 3. Render the selected navigation page with database access
-page = next(p for p in pages if p.label == selected)
+page = next(p for p in pages if p.id == selected_id)
 page.render(session)

--- a/finance_tracker/web/navigation.py
+++ b/finance_tracker/web/navigation.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class Page:
     """Represents a navigation item that can be rendered with a database session."""
+    id: str
     label: str
     render: Callable[[Session], None]
 
@@ -24,20 +25,21 @@ def build_pages() -> list[Page]:
     from finance_tracker.web.views.transactions import render as transactions_render
     from finance_tracker.web.views.valuations import render as valuations_render
     from finance_tracker.web.views.documentation import render as documentation_render
+    from finance_tracker.i18n import t
 
     return [
         # Documentation section
-        Page("📖 Documentation", documentation_render),
+        Page("documentation", t("nav.documentation"), documentation_render),
 
         # Analysis tools
-        Page("📊 Tableau de Bord", dashboard_render),
-        Page("🔮 Simulation Long Terme", simulation_render),
+        Page("dashboard", t("nav.dashboard"), dashboard_render),
+        Page("simulation", t("nav.simulation"), simulation_render),
 
         # Data management
-        Page("🏷️ Mes Produits", products_render),
-        Page("💸 Mes Transactions", transactions_render),
-        Page("📈 Mes Valorisations", valuations_render),
+        Page("products", t("nav.products"), products_render),
+        Page("transactions", t("nav.transactions"), transactions_render),
+        Page("valuations", t("nav.valuations"), valuations_render),
 
         # Specialized tools
-        Page("₿ Espace Bitcoin", bitcoin_render),
+        Page("bitcoin", t("nav.bitcoin"), bitcoin_render),
         ]

--- a/finance_tracker/web/views/bitcoin.py
+++ b/finance_tracker/web/views/bitcoin.py
@@ -5,19 +5,11 @@ Le contenu Bitcoin a été intégré dans le Tableau de Bord (section "Détail p
 import streamlit as st
 from sqlmodel import Session
 
+from finance_tracker.i18n import t
+
 
 def render(session: Session) -> None:
     """Render the Bitcoin transition page."""
-    st.title("₿ Espace Bitcoin")
-    st.info(
-        "**Cette page a été fusionnée dans le Tableau de Bord.**\n\n"
-        "Toutes les fonctionnalités Bitcoin sont désormais accessibles depuis "
-        "**📊 Tableau de Bord → 🔍 Détail par produit → Bitcoin** :\n\n"
-        "- 🔴 Cours live BTC/EUR avec badge LIVE / OFFLINE\n"
-        "- 📦 Quantité en Satoshis\n"
-        "- 📌 PRU et 📈 P&L latente\n"
-        "- 📉 Historique des prix (snapshots)\n"
-        "- 📸 Formulaire de nouveau snapshot\n"
-        "- 🗓️ Tableau des derniers snapshots"
-    )
-    st.markdown("➡️ Rendez-vous dans **📊 Tableau de Bord** pour accéder à votre espace Bitcoin.")
+    st.title(t("bitcoin.title"))
+    st.info(t("bitcoin.redirect_info"))
+    st.markdown(t("bitcoin.redirect_link"))

--- a/finance_tracker/web/views/dashboard.py
+++ b/finance_tracker/web/views/dashboard.py
@@ -12,6 +12,7 @@ import streamlit as st
 
 # Local imports (par ordre alphabétique)
 from finance_tracker.domain.models import Valuation
+from finance_tracker.i18n import t
 from finance_tracker.services.btc_price_service import BTCPriceService, BTCPriceServiceError
 from finance_tracker.services.dashboard_service import DashboardService
 from finance_tracker.services.pdf_report_service import PDFReportService
@@ -69,8 +70,8 @@ def _render_bitcoin_expander(details: dict, product_id: int, service: "Dashboard
 
     col_refresh, _ = st.columns([1, 3])
     with col_refresh:
-        if st.button("🔄 Actualiser le cours", key=f"btc_refresh_{product_id}", width="stretch"):
-            with st.spinner("Connexion aux APIs..."):
+        if st.button(t("dashboard.btc_refresh_btn"), key=f"btc_refresh_{product_id}", width="stretch"):
+            with st.spinner(t("dashboard.btc_connecting")):
                 try:
                     st.session_state.btc_price = float(BTCPriceService().get_btc_price_eur())
                     st.session_state.api_error = None
@@ -79,92 +80,94 @@ def _render_bitcoin_expander(details: dict, product_id: int, service: "Dashboard
                     st.session_state.api_error = True
 
     if st.session_state.get("api_error"):
-        st.warning("📡 **Hors ligne** — Réseau inaccessible. Saisissez le prix manuellement ci-dessous.")
+        st.warning(t("dashboard.btc_offline"))
 
     # ── Key indicators ───────────────────────────────────────────────────────────
     k1, k2, k3, k4 = st.columns(4)
     with k1:
-        st.metric("💼 Valeur actuelle", format_eur(latest_total) if latest_total else "—")
+        st.metric(t("dashboard.btc_metric_value"), format_eur(latest_total) if latest_total else "—")
     with k2:
-        st.metric("📦 Quantité", _fmt_sats(total_qty_sats) if total_qty_sats > 0 else "—")
+        st.metric(t("dashboard.btc_metric_qty"), _fmt_sats(total_qty_sats) if total_qty_sats > 0 else "—")
     with k3:
-        st.metric("📌 PRU", format_eur(pru) if pru else "—")
+        st.metric(t("dashboard.btc_metric_pru"), format_eur(pru) if pru else "—")
     with k4:
         if pnl_eur is not None and pnl_pct is not None:
-            st.metric("📈 P&L Latente", format_eur(pnl_eur), delta=f"{pnl_pct:+.2f}%", delta_color="normal")
+            st.metric(t("dashboard.btc_metric_pnl"), format_eur(pnl_eur), delta=f"{pnl_pct:+.2f}%", delta_color="normal")
         else:
-            st.metric("📈 P&L Latente", "—")
+            st.metric(t("dashboard.btc_metric_pnl"), "—")
 
     # ── Price history chart ──────────────────────────────────────────────────────
     if len(history) >= 2:
-        st.markdown("##### 📉 Historique des prix (snapshots)")
+        st.markdown(f"##### {t('dashboard.btc_price_history')}")
+        col_btc_price = t("dashboard.col_btc_price")
         price_rows = [
-            {"date": pd.Timestamp(v["date"]), "Prix BTC (€)": v["unit_price_eur"]}
+            {"date": pd.Timestamp(v["date"]), col_btc_price: v["unit_price_eur"]}
             for v in history if v["unit_price_eur"]
         ]
         if price_rows:
             chart_df = pd.DataFrame(price_rows)
             base = alt.Chart(chart_df).encode(
-                x=alt.X("date:T", title="Date", axis=alt.Axis(format="%b %Y")),
+                x=alt.X("date:T", title=t("dashboard.col_date"), axis=alt.Axis(format="%b %Y")),
             )
             line = base.mark_line(color="#F7931A", strokeWidth=2.5).encode(
-                y=alt.Y("Prix BTC (€):Q", title="Prix BTC (€)"),
+                y=alt.Y(f"{col_btc_price}:Q", title=col_btc_price),
                 tooltip=[
-                    alt.Tooltip("date:T", title="Date", format="%d/%m/%Y"),
-                    alt.Tooltip("Prix BTC (€):Q", title="Prix (€)", format=",.0f"),
+                    alt.Tooltip("date:T", title=t("dashboard.col_date"), format="%d/%m/%Y"),
+                    alt.Tooltip(f"{col_btc_price}:Q", title=col_btc_price, format=",.0f"),
                 ],
             )
-            pts = base.mark_circle(color="#F7931A", size=40).encode(y="Prix BTC (€):Q")
+            pts = base.mark_circle(color="#F7931A", size=40).encode(y=f"{col_btc_price}:Q")
             chart = (line + pts).properties(height=240)
             if pru:
+                pru_label = t("dashboard.btc_metric_pru")
                 pru_df = pd.DataFrame([
-                    {"date": chart_df["date"].min(), "PRU": pru},
-                    {"date": chart_df["date"].max(), "PRU": pru},
+                    {"date": chart_df["date"].min(), pru_label: pru},
+                    {"date": chart_df["date"].max(), pru_label: pru},
                 ])
                 pru_line = alt.Chart(pru_df).mark_line(
                     color="#6366f1", strokeDash=[6, 4], strokeWidth=1.8,
                 ).encode(
                     x="date:T",
-                    y=alt.Y("PRU:Q"),
-                    tooltip=[alt.Tooltip("PRU:Q", title="PRU (€)", format=",.0f")],
+                    y=alt.Y(f"{pru_label}:Q"),
+                    tooltip=[alt.Tooltip(f"{pru_label}:Q", title=f"{pru_label} (€)", format=",.0f")],
                 )
                 chart = (chart + pru_line).properties(height=240)
             st.altair_chart(chart, use_container_width=True)
-            legend_parts = ["<span style='color:#F7931A'>■</span> Prix BTC"]
+            legend_parts = [f"<span style='color:#F7931A'>■</span> {t('dashboard.col_btc_price')}"]
             if pru:
-                legend_parts.append("<span style='color:#6366f1'>- -</span> PRU")
+                legend_parts.append(f"<span style='color:#6366f1'>- -</span> {t('dashboard.btc_metric_pru')}")
             st.markdown(
                 "<span style='font-size:0.85em;color:gray'>" + " · ".join(legend_parts) + "</span>",
                 unsafe_allow_html=True,
             )
 
     # ── Snapshot form ────────────────────────────────────────────────────────────
-    st.markdown("##### 📸 Nouveau Snapshot")
+    st.markdown(f"##### {t('dashboard.btc_new_snapshot')}")
     default_price = live_price or (last_unit_price or 0.0)
     with st.form(f"btc_snapshot_{product_id}", clear_on_submit=True):
         fc1, fc2, fc3 = st.columns(3)
         with fc1:
-            val_date = st.date_input("Date", value=date.today())
+            val_date = st.date_input(t("dashboard.btc_date_label"), value=date.today())
         with fc2:
             btc_unit_price = st.number_input(
-                "Prix d'un BTC plein (EUR)",
+                t("dashboard.btc_full_price_label"),
                 value=float(default_price),
                 step=100.0,
             )
         with fc3:
             input_sats = st.number_input(
-                "Quantité (en Satoshis)",
+                t("dashboard.btc_qty_label"),
                 value=int(total_qty_sats),
                 step=100_000,
                 format="%d",
-                help="1 BTC = 100 000 000 Sats",
+                help=t("dashboard.btc_qty_help"),
             )
         if btc_unit_price > 0 and input_sats > 0:
             qty_btc_preview = input_sats / SATS_PER_BTC
-            st.info(f"💶 Valeur calculée : **{format_eur(btc_unit_price * qty_btc_preview)}**")
-        if st.form_submit_button("💾 Enregistrer le snapshot", type="primary", width="stretch"):
+            st.info(t("dashboard.btc_computed_value").format(v=format_eur(btc_unit_price * qty_btc_preview)))
+        if st.form_submit_button(t("dashboard.btc_save_snapshot"), type="primary", width="stretch"):
             if input_sats <= 0 or btc_unit_price <= 0:
-                st.error("La quantité (en sats) et le prix doivent être > 0.")
+                st.error(t("dashboard.btc_qty_error"))
             else:
                 try:
                     qty_btc_final = input_sats / SATS_PER_BTC
@@ -175,10 +178,10 @@ def _render_bitcoin_expander(details: dict, product_id: int, service: "Dashboard
                         total_value_eur=to_decimal(total_val),
                         unit_price_eur=to_decimal(btc_unit_price),
                     ))
-                    st.success(f"✅ Snapshot enregistré — Valeur : {format_eur(total_val)}")
+                    st.success(t("dashboard.btc_snapshot_saved").format(v=format_eur(total_val)))
                     st.rerun()
                 except Exception as e:
-                    st.error(f"❌ Erreur : {e}")
+                    st.error(t("dashboard.btc_error").format(e=e))
 
     # ── Recent snapshots table ───────────────────────────────────────────────────
     if history:
@@ -190,10 +193,10 @@ def _render_bitcoin_expander(details: dict, product_id: int, service: "Dashboard
             sats = int((val_eur / prix_unit) * SATS_PER_BTC) if prix_unit > 0 else 0
             d = v["date"]
             rows_btc.append({
-                "Date": d.strftime("%d/%m/%Y") if hasattr(d, "strftime") else str(d),
-                "Prix BTC (€)": f"{prix_unit:,.0f}".replace(",", " ") if prix_unit > 0 else "—",
-                "Satoshis": f"{sats:,}".replace(",", " ") if sats > 0 else "—",
-                "Valeur totale (€)": f"{val_eur:,.2f}".replace(",", " "),
+                t("dashboard.col_date"): d.strftime("%d/%m/%Y") if hasattr(d, "strftime") else str(d),
+                t("dashboard.col_btc_price"): f"{prix_unit:,.0f}".replace(",", " ") if prix_unit > 0 else "—",
+                t("dashboard.col_sats"): f"{sats:,}".replace(",", " ") if sats > 0 else "—",
+                t("dashboard.col_total_value"): f"{val_eur:,.2f}".replace(",", " "),
             })
         st.dataframe(pd.DataFrame(rows_btc), hide_index=True, use_container_width=True)
 
@@ -281,48 +284,9 @@ def _render_generic_expander(details: dict) -> None:
 
 
 def render(session: Session) -> None:
-    """
-    Render the main dashboard page in the Streamlit application.
-
-    This page provides a comprehensive overview of the investment portfolio,
-    including key performance indicators, allocation breakdown, and export
-    capabilities.
-
-    The page is organized into three main sections:
-
-    1. Overview KPIs - Total value, invested amount, gains, and cash
-    2. Portfolio Allocation - Horizontal bar chart and detailed table
-    3. Exports & Reports - PDF and JSON download functionality
-
-    Parameters
-    ----------
-    session : Session
-        SQLModel database session for repository operations.
-
-    Returns
-    -------
-    None
-        This function renders UI components directly to Streamlit.
-
-    Notes
-    -----
-    - Performance percentage is calculated as (gains / invested) * 100
-    - Allocation chart uses Altair with horizontal bars
-    - PDF and JSON exports are cached in st.session_state to avoid
-      regenerating on each page refresh
-    - A refresh button allows clearing the cache to force regeneration
-
-    The function gracefully handles empty portfolios by displaying
-    an informational message guiding users to add valuations.
-
-    Examples
-    --------
-    >>> from finance_tracker.web.db import get_session
-    >>> session = get_session()
-    >>> render(session)  # Renders the dashboard in Streamlit
-    """
-    st.title("📊 Tableau de bord")
-    st.caption("Aperçu global et performances de votre portefeuille d'investissement.")
+    """Render the main dashboard page in the Streamlit application."""
+    st.title(t("dashboard.title"))
+    st.caption(t("dashboard.caption"))
 
     # Initialize dashboard service and build portfolio data
     service = DashboardService(session)
@@ -330,15 +294,14 @@ def render(session: Session) -> None:
     try:
         portfolio = service.build_portfolio()
     except Exception as e:
-        st.error(f"Impossible de charger le portefeuille : {e}")
-
+        st.error(t("dashboard.load_error").format(e=e))
         return
 
     # ═══════════════════════════════════════════════════════════════════════════
     # SECTION 1: KEY PERFORMANCE INDICATORS
     # ═══════════════════════════════════════════════════════════════════════════
 
-    st.markdown("### 📈 Vue d'ensemble")
+    st.markdown(f"### {t('dashboard.section_overview')}")
 
     # Calculate performance percentage (handle division by zero)
     perf_pct = (
@@ -352,19 +315,19 @@ def render(session: Session) -> None:
     col1, col2, col3, col4 = st.columns(4)
 
     with col1:
-        st.metric(label="💼 Valeur Totale", value=format_eur(portfolio.total_value_eur))
+        st.metric(label=t("dashboard.metric_total_value"), value=format_eur(portfolio.total_value_eur))
     with col2:
-        st.metric(label="📥 Total Investi", value=format_eur(portfolio.total_invested_eur))
+        st.metric(label=t("dashboard.metric_total_invested"), value=format_eur(portfolio.total_invested_eur))
     with col3:
         st.metric(
-            label="📈 Plus-values",
+            label=t("dashboard.metric_gains"),
             value=format_eur(portfolio.total_gains_eur),
             delta=f"{perf_pct:.2f}%",
             delta_color="normal",
         )
 
     with col4:
-        st.metric(label="💶 Cash disponible", value=format_eur(portfolio.cash_available))
+        st.metric(label=t("dashboard.metric_cash"), value=format_eur(portfolio.cash_available))
 
     st.markdown("---")
 
@@ -372,7 +335,7 @@ def render(session: Session) -> None:
     # SECTION 2: PORTFOLIO ALLOCATION
     # ═══════════════════════════════════════════════════════════════════════════
 
-    st.markdown("### 🧩 Répartition du portefeuille")
+    st.markdown(f"### {t('dashboard.section_allocation')}")
 
     # Build rows for products with non-zero value or contributions
     rows = []
@@ -381,20 +344,22 @@ def render(session: Session) -> None:
         if p.get("current_value_eur", 0) > 0 or p.get("net_contributions_eur", 0) > 0:
             rows.append(
                 {
-                    "Produit": p["name"],
+                    t("dashboard.chart_product"): p["name"],
                     "Valeur_brute": float(p["current_value_eur"]),  # For sorting
                     "Valeur": f"{float(p['current_value_eur']):.2f} €",
                     "Investi": f"{float(p['net_contributions_eur']):.2f} €",
                     "Gains": f"{float(p['performance_eur']):.2f} €",
                     "Perf %": f"{float(p['performance_pct']):.2f} %",
-                    "Allocation": float(p["allocation_pct"]),
+                    t("dashboard.chart_weight_pct"): float(p["allocation_pct"]),
                 }
             )
 
     if rows:
         df = pd.DataFrame(rows)
+        product_col = t("dashboard.chart_product")
+        weight_col = t("dashboard.chart_weight_pct")
         # Sort by allocation ascending (for horizontal bar chart)
-        df_sorted = df.sort_values("Allocation", ascending=True)
+        df_sorted = df.sort_values(weight_col, ascending=True)
 
         c_chart, c_table = st.columns([1, 1.6])
 
@@ -407,24 +372,24 @@ def render(session: Session) -> None:
                 .mark_bar(cornerRadiusTopRight=4, cornerRadiusBottomRight=4)
                 .encode(
                     x=alt.X(
-                        "Allocation:Q",
-                        title="Poids (%)",
+                        f"{weight_col}:Q",
+                        title=weight_col,
                         scale=alt.Scale(domain=[0, 100]),
                     ),
                     y=alt.Y(
-                        "Produit:N",
+                        f"{product_col}:N",
                         sort=None,  # Preserve dataframe order
                         title="",
                         axis=alt.Axis(labelLimit=150),
                     ),
                     color=alt.Color(
-                        "Produit:N",
+                        f"{product_col}:N",
                         legend=None,  # Legend in table instead
                         scale=alt.Scale(scheme="tableau10"),
                     ),
                     tooltip=[
-                        alt.Tooltip("Produit:N", title="Produit"),
-                        alt.Tooltip("Allocation:Q", title="Poids (%)", format=".1f"),
+                        alt.Tooltip(f"{product_col}:N", title=product_col),
+                        alt.Tooltip(f"{weight_col}:Q", title=weight_col, format=".1f"),
                         alt.Tooltip("Valeur:N", title="Valeur"),
                     ],
                 )
@@ -444,16 +409,14 @@ def render(session: Session) -> None:
                 width="stretch",
                 hide_index=True,
                 column_config={
-                    "Allocation": st.column_config.ProgressColumn(
-                        "Poids (%)", min_value=0, max_value=100, format="%.1f%%"
+                    weight_col: st.column_config.ProgressColumn(
+                        weight_col, min_value=0, max_value=100, format="%.1f%%"
                     )
                 },
             )
     else:
         # Empty portfolio message
-        st.info(
-            "💡 Votre portefeuille est vide. Ajoutez des valorisations dans l'onglet correspondant."
-        )
+        st.info(t("dashboard.empty_portfolio"))
 
     st.markdown("---")
 
@@ -461,7 +424,7 @@ def render(session: Session) -> None:
     # SECTION 2b: PER-PRODUCT DETAIL SECTIONS
     # ═══════════════════════════════════════════════════════════════════════════
 
-    st.markdown("### 🔍 Détail par produit")
+    st.markdown(f"### {t('dashboard.section_detail')}")
 
     for p in portfolio.products:
         if p.get("current_value_eur", 0) <= 0:
@@ -484,7 +447,7 @@ def render(session: Session) -> None:
     # SECTION 3: EXPORTS & REPORTS
     # ═══════════════════════════════════════════════════════════════════════════
 
-    st.markdown("### 🖨️ Exports & Rapports")
+    st.markdown(f"### {t('dashboard.section_exports')}")
     c1, c2, _ = st.columns([1, 1, 2])
 
     # ═══════════════════════════════════════════════════════════════════════════
@@ -498,8 +461,8 @@ def render(session: Session) -> None:
         if pdf_cache_key not in st.session_state:
             # First state: show generate button
 
-            if st.button("⚙️ Préparer le rapport PDF", width="stretch"):
-                with st.spinner("⏳ Génération du rapport PDF..."):
+            if st.button(t("dashboard.prepare_pdf"), width="stretch"):
+                with st.spinner(t("dashboard.generating_pdf")):
                     try:
                         # Build per-product chart data for PDF
                         chart_details = []
@@ -518,13 +481,13 @@ def render(session: Session) -> None:
 
                         st.rerun()
                     except Exception as e:
-                        st.error(f"❌ Error: {e}")
+                        st.error(t("dashboard.error").format(e=e))
         else:
             # Cached state: show download button
             st.download_button(
-                "⬇️ Télécharger le PDF",
+                t("dashboard.download_pdf"),
                 data=st.session_state[pdf_cache_key],
-                file_name="rapport_portefeuille.pdf",
+                file_name=t("dashboard.pdf_filename"),
                 mime="application/pdf",
                 type="primary",
                 width="stretch",
@@ -541,20 +504,20 @@ def render(session: Session) -> None:
         if json_cache_key not in st.session_state:
             # First state: show generate button
 
-            if st.button("⚙️ Préparer l'export JSON", width="stretch"):
-                with st.spinner("⏳ Structuration des données..."):
+            if st.button(t("dashboard.prepare_json"), width="stretch"):
+                with st.spinner(t("dashboard.generating_json")):
                     try:
                         json_data = service.export_json(portfolio)
                         st.session_state[json_cache_key] = json_data
                         st.rerun()
                     except Exception as e:
-                        st.error(f"❌ Error: {e}")
+                        st.error(t("dashboard.error").format(e=e))
         else:
             # Cached state: show download button
             st.download_button(
-                "⬇️ Télécharger le JSON",
+                t("dashboard.download_json"),
                 data=st.session_state[json_cache_key],
-                file_name="dashboard_data.json",
+                file_name=t("dashboard.json_filename"),
                 mime="application/json",
                 type="primary",
                 width="stretch",
@@ -567,7 +530,7 @@ def render(session: Session) -> None:
     # Show refresh button only if there's cached data
 
     if pdf_cache_key in st.session_state or json_cache_key in st.session_state:
-        if st.button("🔄 Rafraîchir les données d'export", type="secondary"):
+        if st.button(t("dashboard.refresh_exports"), type="secondary"):
             # Clear cached exports to force regeneration
             st.session_state.pop(pdf_cache_key, None)
             st.session_state.pop(json_cache_key, None)

--- a/finance_tracker/web/views/documentation.py
+++ b/finance_tracker/web/views/documentation.py
@@ -10,6 +10,8 @@ import streamlit as st
 from sqlmodel import Session
 from pathlib import Path
 
+from finance_tracker.i18n import t
+
 
 # GitHub repository base URL for markdown files
 GITHUB_BASE_URL = "https://github.com/SKOHscripts/finance-tracker/blob/main"
@@ -19,53 +21,27 @@ DOCS_GITHUB_URL = f"{GITHUB_BASE_URL}/docs"
 def _get_docs_path() -> Path:
     """Get the absolute path to the docs directory."""
     current_dir = Path(__file__).parent.parent.parent.parent
-
     return current_dir / "docs"
 
 
 def _load_markdown_file(filename: str) -> str:
-    """
-    Load markdown content from a file in the docs directory.
-
-    Returns an error message if the file cannot be found or read.
-
-    Parameters
-    ----------
-    filename : str
-        Name of the markdown file to load (e.g., "CONCEPTS_FONDAMENTAUX.md").
-
-    Returns
-    -------
-    str
-        Content of the file as a string, or an error message if the file
-        was not found or could not be read.
-    """
+    """Load markdown content from a file in the docs directory."""
     try:
         docs_path = _get_docs_path()
         file_path = docs_path / filename
 
         if not file_path.exists():
-            return f"⚠️ Fichier {filename} introuvable."
+            return t("documentation.file_not_found").format(filename=filename)
 
         with open(file_path, "r", encoding="utf-8") as f:
             return f.read()
     except Exception as e:
-        return f"❌ Erreur lors du chargement du fichier: {str(e)}"
-
-
-def _render_github_link(filename: str, label: str = "Voir sur GitHub") -> str:
-    """Generate a GitHub link for a documentation file."""
-
-    if filename.startswith("docs/"):
-        url = f"{GITHUB_BASE_URL}/{filename}"
-    else:
-        url = f"{DOCS_GITHUB_URL}/{filename}"
-
-    return f"🔗 [{label}]({url})"
+        return t("documentation.file_load_error").format(error=str(e))
 
 
 def _render_section_card(title: str, description: str, icon: str, link_url: str) -> None:
     """Render a clickable section card with icon and description."""
+    read_more = t("documentation.card_read_more")
     st.markdown(f"""
     <div style="background: linear-gradient(135deg, #1e3a5f 0%, #2d4a6f 100%);
                 padding: 1.2rem;
@@ -74,7 +50,7 @@ def _render_section_card(title: str, description: str, icon: str, link_url: str)
                 border-left: 4px solid #4da6ff;">
         <h4 style="margin: 0; color: #ffffff;">{icon} {title}</h4>
         <p style="margin: 0.5rem 0 0 0; color: #b8c9d9; font-size: 0.9rem;">{description}</p>
-        <a href="{link_url}" target="_blank" style="color: #4da6ff; font-size: 0.85rem;">📖 Lire la documentation complète →</a>
+        <a href="{link_url}" target="_blank" style="color: #4da6ff; font-size: 0.85rem;">{read_more}</a>
     </div>
     """, unsafe_allow_html=True)
 
@@ -82,12 +58,8 @@ def _render_section_card(title: str, description: str, icon: str, link_url: str)
 def _render_tab_home() -> None:
     """Render the home/welcome tab with project overview."""
 
-    st.markdown("""
-    ## 👋 Bienvenue dans Finance Tracker
-
-    **Finance Tracker** est une application complète de gestion de portefeuille d'investissement,
-    conçue pour les investisseurs francophones soucieux de leur vie privée.
-    """)
+    st.markdown(f"## {t('documentation.home_title')}")
+    st.markdown(t("documentation.home_intro"))
 
     # Badges
     st.markdown("""
@@ -98,76 +70,40 @@ def _render_tab_home() -> None:
 
     st.divider()
 
-    # Features overview
-    st.markdown("### ✨ Fonctionnalités Principales")
+    st.markdown(f"### {t('documentation.home_features_title')}")
 
     col1, col2, col3 = st.columns(3)
 
     with col1:
-        st.markdown("""
-        **📊 Suivi Complet**
-        - Portefeuille multi-actifs
-        - SCPI, Bitcoin, Livrets
-        - Assurance-vie, PER
-        """)
+        st.markdown(t("documentation.home_feature_tracking"))
 
     with col2:
-        st.markdown("""
-        **📈 Analyses Avancées**
-        - Performance MWRR
-        - Intérêts composés
-        - Projections long terme
-        """)
+        st.markdown(t("documentation.home_feature_analysis"))
 
     with col3:
-        st.markdown("""
-        **🔒 Vie Privée**
-        - Données locales
-        - Aucun cloud requis
-        - Export/Import facile
-        """)
+        st.markdown(t("documentation.home_feature_privacy"))
 
     st.divider()
 
-    # Quick start
-    st.markdown("### 🚀 Démarrage Rapide")
-
-    st.markdown("""
-    | Étape | Action | Page |
-    |-------|--------|------|
-    | 1️⃣ | Créer vos produits | 🏷️ **Mes Produits** |
-    | 2️⃣ | Ajouter des transactions | 💸 **Mes Transactions** |
-    | 3️⃣ | Mettre à jour les valorisations | 📈 **Mes Valorisations** |
-    | 4️⃣ | Consulter le tableau de bord | 📊 **Tableau de Bord** |
-    """)
+    st.markdown(f"### {t('documentation.home_quickstart_title')}")
+    st.markdown(t("documentation.home_quickstart_table"))
 
     st.divider()
 
-    # Links to documentation
-    st.markdown("### 📚 Explorer la Documentation")
-
-    st.markdown("Utilisez les **onglets ci-dessus** pour accéder aux différentes sections de documentation.")
-
-    st.info("""
-    **💡 Astuce:** Commencez par l'onglet **📚 Concepts** pour comprendre les 3 piliers
-    du système (Produits, Transactions, Valorisations) avant d'utiliser l'application.
-    """)
+    st.markdown(f"### {t('documentation.home_explore_title')}")
+    st.markdown(t("documentation.home_explore_text"))
+    st.info(t("documentation.home_tip"))
 
 
 def _render_tab_concepts() -> None:
     """Render the fundamental concepts documentation tab."""
 
-    st.markdown("""
-    ## 📚 Concepts Fondamentaux
-
-    Finance Tracker repose sur **trois piliers** essentiels. Comprendre ces concepts
-    est la clé pour utiliser efficacement l'application.
-    """)
+    st.markdown(f"## {t('documentation.concepts_title')}")
+    st.markdown(t("documentation.concepts_intro"))
 
     st.divider()
 
-    # Pillar 1: Products
-    st.markdown("### 1️⃣ Produits (Products)")
+    st.markdown(f"### {t('documentation.concepts_products_title')}")
     st.markdown("""
     Un **Produit** représente le contenant de votre investissement. C'est l'objet stable
     créé une seule fois qui ne change jamais.
@@ -183,8 +119,7 @@ def _render_tab_concepts() -> None:
     | PER | Aucun | PER Retraite | Variable |
     """)
 
-    # Pillar 2: Transactions
-    st.markdown("### 2️⃣ Transactions (Mouvements)")
+    st.markdown(f"### {t('documentation.concepts_transactions_title')}")
     st.markdown("""
     Une **Transaction** enregistre un flux d'argent ou de quantité à un instant T.
 
@@ -199,8 +134,7 @@ def _render_tab_concepts() -> None:
     | FEE | ← Sortie | Frais payés |
     """)
 
-    # Pillar 3: Valuations
-    st.markdown("### 3️⃣ Valorisations (Snapshots)")
+    st.markdown(f"### {t('documentation.concepts_valuations_title')}")
     st.markdown("""
     Une **Valorisation** capture la valeur unitaire d'un produit à un instant donné.
     C'est une "photographie" qui permet de calculer les gains/pertes latents.
@@ -215,13 +149,12 @@ def _render_tab_concepts() -> None:
 
     st.divider()
 
-    # Link to full documentation
-    st.markdown(f"""
-    🔗 **[Lire la documentation complète: Concepts Fondamentaux]({DOCS_GITHUB_URL}/CONCEPTS_FONDAMENTAUX.md)**
-    """)
+    st.markdown(t("documentation.full_doc_link").format(
+        title="Concepts Fondamentaux",
+        url=f"{DOCS_GITHUB_URL}/CONCEPTS_FONDAMENTAUX.md",
+    ))
 
-    # Expandable full content
-    with st.expander("📄 Voir le document complet", expanded=False):
+    with st.expander(t("documentation.expand_full_doc"), expanded=False):
         content = _load_markdown_file("CONCEPTS_FONDAMENTAUX.md")
         st.markdown(content)
 
@@ -229,17 +162,12 @@ def _render_tab_concepts() -> None:
 def _render_tab_calculs() -> None:
     """Render the formulas and calculations documentation tab."""
 
-    st.markdown("""
-    ## 📐 Formules & Calculs
-
-    Toutes les formules mathématiques utilisées par Finance Tracker pour calculer
-    les performances, gains et projections.
-    """)
+    st.markdown(f"## {t('documentation.calculs_title')}")
+    st.markdown(t("documentation.calculs_intro"))
 
     st.divider()
 
-    # Key indicators
-    st.markdown("### 📊 Indicateurs Clés")
+    st.markdown(f"### {t('documentation.calculs_key_metrics')}")
 
     col1, col2 = st.columns(2)
 
@@ -283,8 +211,7 @@ def _render_tab_calculs() -> None:
 
     st.divider()
 
-    # Compound interest
-    st.markdown("### 📈 Intérêts Composés")
+    st.markdown(f"### {t('documentation.calculs_compound')}")
 
     st.markdown("""
     **Formule classique:**
@@ -303,8 +230,7 @@ def _render_tab_calculs() -> None:
 
     st.divider()
 
-    # Bitcoin specifics
-    st.markdown("### ₿ Cas Spécial: Bitcoin")
+    st.markdown(f"### {t('documentation.calculs_bitcoin_title')}")
 
     st.markdown("""
     **Conversion sans double passage:**
@@ -319,12 +245,12 @@ def _render_tab_calculs() -> None:
 
     st.divider()
 
-    # Link to full documentation
-    st.markdown(f"""
-    🔗 **[Lire la documentation complète: Formules & Calculs]({DOCS_GITHUB_URL}/FORMULES_CALCULS.md)**
-    """)
+    st.markdown(t("documentation.full_doc_link").format(
+        title="Formules & Calculs",
+        url=f"{DOCS_GITHUB_URL}/FORMULES_CALCULS.md",
+    ))
 
-    with st.expander("📄 Voir le document complet", expanded=False):
+    with st.expander(t("documentation.expand_full_doc"), expanded=False):
         content = _load_markdown_file("FORMULES_CALCULS.md")
         st.markdown(content)
 
@@ -332,16 +258,12 @@ def _render_tab_calculs() -> None:
 def _render_tab_interface() -> None:
     """Render the web interface documentation tab."""
 
-    st.markdown("""
-    ## 💻 Guide Interface Web
-
-    Guide complet page par page de l'interface Streamlit.
-    """)
+    st.markdown(f"## {t('documentation.interface_title')}")
+    st.markdown(t("documentation.interface_intro"))
 
     st.divider()
 
-    # Pages overview
-    st.markdown("### 📑 Architecture de l'Application")
+    st.markdown(f"### {t('documentation.interface_architecture')}")
 
     pages_data = {
         "📊 Tableau de Bord": "Vue globale du portefeuille, répartition, graphiques temporels",
@@ -359,8 +281,7 @@ def _render_tab_interface() -> None:
 
     st.divider()
 
-    # Key workflows
-    st.markdown("### 🔄 Flux de Travail Recommandé")
+    st.markdown(f"### {t('documentation.interface_workflow')}")
 
     st.markdown("""
     ```
@@ -381,8 +302,7 @@ def _render_tab_interface() -> None:
 
     st.divider()
 
-    # Transaction types detail
-    st.markdown("### 💰 Types de Transactions")
+    st.markdown(f"### {t('documentation.interface_tx_types')}")
 
     st.markdown("""
     | Type | Quand l'utiliser | Impact sur Cash | Impact Investissement Net |
@@ -397,12 +317,12 @@ def _render_tab_interface() -> None:
 
     st.divider()
 
-    # Link to full documentation
-    st.markdown(f"""
-    🔗 **[Lire la documentation complète: Interface Web]({DOCS_GITHUB_URL}/INTERFACE_WEB.md)**
-    """)
+    st.markdown(t("documentation.full_doc_link").format(
+        title="Interface Web",
+        url=f"{DOCS_GITHUB_URL}/INTERFACE_WEB.md",
+    ))
 
-    with st.expander("📄 Voir le document complet", expanded=False):
+    with st.expander(t("documentation.expand_full_doc"), expanded=False):
         content = _load_markdown_file("INTERFACE_WEB.md")
         st.markdown(content)
 
@@ -410,16 +330,12 @@ def _render_tab_interface() -> None:
 def _render_tab_installation() -> None:
     """Render the installation and developer documentation tab."""
 
-    st.markdown("""
-    ## 🛠️ Installation & Développement
-
-    Guides pour installer, configurer et contribuer au projet.
-    """)
+    st.markdown(f"## {t('documentation.install_title')}")
+    st.markdown(t("documentation.install_intro"))
 
     st.divider()
 
-    # Quick start
-    st.markdown("### ⚡ Démarrage Rapide (Développeur)")
+    st.markdown(f"### {t('documentation.install_quickstart')}")
 
     st.code("""
 # Cloner le dépôt
@@ -444,8 +360,7 @@ streamlit run app.py
 
     st.divider()
 
-    # Architecture
-    st.markdown("### 🧱 Architecture du Projet")
+    st.markdown(f"### {t('documentation.install_architecture')}")
 
     st.markdown("""
     ```
@@ -465,43 +380,38 @@ streamlit run app.py
 
     st.divider()
 
-    # Links to full documentation
-    st.markdown("### 🔗 Documentation Développeur")
+    st.markdown(f"### {t('documentation.install_dev_docs')}")
 
     col1, col2 = st.columns(2)
 
     with col1:
         st.markdown(f"""
         **Installation complète:**
-        🔗 [INSTALLATION_SETUP.md]({DOCS_GITHUB_URL}/INSTALLATION_SETUP.md)
+        [{DOCS_GITHUB_URL}/INSTALLATION_SETUP.md]({DOCS_GITHUB_URL}/INSTALLATION_SETUP.md)
 
         **Guide CLI:**
-        🔗 [CLI_GUIDE.md]({DOCS_GITHUB_URL}/CLI_GUIDE.md)
+        [{DOCS_GITHUB_URL}/CLI_GUIDE.md]({DOCS_GITHUB_URL}/CLI_GUIDE.md)
         """)
 
     with col2:
         st.markdown(f"""
         **Base de données:**
-        🔗 [BASE_DONNEES.md]({DOCS_GITHUB_URL}/BASE_DONNEES.md)
+        [{DOCS_GITHUB_URL}/BASE_DONNEES.md]({DOCS_GITHUB_URL}/BASE_DONNEES.md)
 
         **Documentation technique:**
-        🔗 [DOCUMENTATION_TECHNIQUE.md]({DOCS_GITHUB_URL}/DOCUMENTATION_TECHNIQUE.md)
+        [{DOCS_GITHUB_URL}/DOCUMENTATION_TECHNIQUE.md]({DOCS_GITHUB_URL}/DOCUMENTATION_TECHNIQUE.md)
         """)
 
 
 def _render_tab_database() -> None:
     """Render the database documentation tab."""
 
-    st.markdown("""
-    ## 🗄️ Structure de la Base de Données
-
-    Finance Tracker utilise **SQLite** avec **SQLModel** pour la persistance des données.
-    """)
+    st.markdown(f"## {t('documentation.database_title')}")
+    st.markdown(t("documentation.database_intro"))
 
     st.divider()
 
-    # Main tables
-    st.markdown("### 📊 Tables Principales")
+    st.markdown(f"### {t('documentation.database_tables')}")
 
     st.markdown("""
     **PRODUCTS (Produits)**
@@ -541,8 +451,7 @@ def _render_tab_database() -> None:
 
     st.divider()
 
-    # Relations
-    st.markdown("### 🔗 Relations")
+    st.markdown(f"### {t('documentation.database_relations')}")
 
     st.markdown("""
     ```
@@ -558,12 +467,12 @@ def _render_tab_database() -> None:
 
     st.divider()
 
-    # Link to full documentation
-    st.markdown(f"""
-    🔗 **[Lire la documentation complète: Base de Données]({DOCS_GITHUB_URL}/BASE_DONNEES.md)**
-    """)
+    st.markdown(t("documentation.full_doc_link").format(
+        title="Base de Données",
+        url=f"{DOCS_GITHUB_URL}/BASE_DONNEES.md",
+    ))
 
-    with st.expander("📄 Voir le document complet", expanded=False):
+    with st.expander(t("documentation.expand_full_doc"), expanded=False):
         content = _load_markdown_file("BASE_DONNEES.md")
         st.markdown(content)
 
@@ -571,14 +480,11 @@ def _render_tab_database() -> None:
 def _render_tab_help() -> None:
     """Render the help and support tab."""
 
-    st.markdown("""
-    ## 🆘 Aide & Support
-    """)
+    st.markdown(f"## {t('documentation.help_title')}")
 
     st.divider()
 
-    # FAQ
-    st.markdown("### ❓ FAQ Rapide")
+    st.markdown(f"### {t('documentation.help_faq_title')}")
 
     faq_items = [
         ("Comment créer mon premier portefeuille?", """
@@ -601,7 +507,7 @@ Les gains latents seront calculés automatiquement!
         """),
 
         ("Comment sauvegarder mes données?", """
-1. Dans la **sidebar gauche**, section "💾 Gestion des Données"
+1. Dans la **sidebar gauche**, section "Gestion des Données"
 2. Cliquez "📥 Sauvegarder la base (PC)"
 3. Fichier `.db` téléchargé sur votre ordinateur
 
@@ -615,86 +521,52 @@ le prix en temps réel. Les mises à jour sont automatiques.
         ]
 
     for question, answer in faq_items:
-        with st.expander(f"❓ {question}"):
+        with st.expander(question):
             st.markdown(answer)
 
     st.divider()
 
-    # Resources
-    st.markdown("### 🌐 Ressources")
+    st.markdown(f"### {t('documentation.help_resources_title')}")
 
     col1, col2, col3 = st.columns(3)
 
     with col1:
-        st.markdown("""
-        **📱 Liens Officiels**
-
-        [🌐 Application Web](https://finance-tracker-skohscripts.streamlit.app/)
-
-        [💻 GitHub](https://github.com/SKOHscripts/finance-tracker)
-        """)
+        st.markdown(t("documentation.help_resources_official"))
+        st.markdown(t("documentation.help_resources_web"))
+        st.markdown(t("documentation.help_resources_github"))
 
     with col2:
-        st.markdown("""
-        **💬 Support**
-
-        [🐛 Signaler un bug](https://github.com/SKOHscripts/finance-tracker/issues)
-
-        [💡 Proposer une fonctionnalité](https://github.com/SKOHscripts/finance-tracker/discussions)
-        """)
+        st.markdown(t("documentation.help_resources_support"))
+        st.markdown(t("documentation.help_resources_bug"))
+        st.markdown(t("documentation.help_resources_feature"))
 
     with col3:
-        st.markdown("""
-        **📚 Documentation**
-
-        [📖 README complet]({github}/README.md)
-
-        [🗺️ Roadmap]({docs}/ROADMAP.md)
-        """.format(github=GITHUB_BASE_URL, docs=DOCS_GITHUB_URL))
+        st.markdown(t("documentation.help_resources_docs"))
+        st.markdown(t("documentation.help_resources_readme").format(url=GITHUB_BASE_URL))
+        st.markdown(t("documentation.help_resources_roadmap").format(url=DOCS_GITHUB_URL))
 
     st.divider()
 
-    # Tips
-    st.markdown("### 💡 Conseils d'Utilisation")
-
-    st.info("""
-    **Conseil #1:** Commencez par lire les **📚 Concepts** pour comprendre les 3 piliers du système.
-
-    **Conseil #2:** Mettez à jour vos **📈 Valorisations** régulièrement (mensuellement minimum).
-
-    **Conseil #3:** Utilisez le **🔮 Simulateur** pour planifier vos investissements futurs.
-
-    **Conseil #4:** Sauvegardez régulièrement votre base de données via la sidebar.
-    """)
+    st.markdown(f"### {t('documentation.help_tips_title')}")
+    st.info(t("documentation.help_tips"))
 
 
 def render(session: Session) -> None:
-    """
-    Render the documentation page.
+    """Render the documentation page."""
 
-    Main entry point called from navigation.py.
-    Displays documentation in multiple tabs for better organization.
-
-    Parameters
-    ----------
-        session: SQLModel database session (required by navigation pattern)
-    """
-
-    # Page title
-    st.title("📖 Documentation")
-    st.markdown("Guide complet pour utiliser et comprendre Finance Tracker")
+    st.title(t("documentation.title"))
+    st.markdown(t("documentation.subtitle"))
 
     st.divider()
 
-    # Create tabs
     tabs = st.tabs([
-        "👋 Accueil",
-        "📚 Concepts",
-        "📐 Calculs",
-        "💻 Interface Web",
-        "🗄️ Base de Données",
-        "🛠️ Installation",
-        "🆘 Aide"
+        t("documentation.tab_home"),
+        t("documentation.tab_concepts"),
+        t("documentation.tab_calculs"),
+        t("documentation.tab_interface"),
+        t("documentation.tab_database"),
+        t("documentation.tab_install"),
+        t("documentation.tab_help"),
         ])
 
     tab_home, tab_concepts, tab_calculs, tab_interface, tab_database, tab_install, tab_help = tabs

--- a/finance_tracker/web/views/products.py
+++ b/finance_tracker/web/views/products.py
@@ -5,6 +5,7 @@ from sqlmodel import Session
 
 from finance_tracker.domain.enums import ProductType, QuantityUnit
 from finance_tracker.domain.models import Product
+from finance_tracker.i18n import t
 from finance_tracker.repositories.sqlmodel_repo import (
     SQLModelProductRepository,
     SQLModelTransactionRepository,
@@ -13,29 +14,7 @@ from finance_tracker.repositories.sqlmodel_repo import (
 
 
 def _enum_from_value(enum_cls, value: str):
-    """Retrieve the enum member matching the given value.
-
-    Iterates through the enum class and returns the first member whose
-    value equals the provided string.
-
-    Parameters
-    ----------
-    enum_cls : type
-        The enum class to search within.
-    value : str
-        The string value to match against enum members.
-
-    Returns
-    -------
-    enum.Enum
-        The enum member whose value matches the input string.
-
-    Raises
-    ------
-    ValueError
-        If no enum member matches the provided value.
-    """
-
+    """Retrieve the enum member matching the given value."""
     for e in enum_cls:
         if e.value == value:
             return e
@@ -43,53 +22,9 @@ def _enum_from_value(enum_cls, value: str):
 
 
 def render(session: Session) -> None:
-    """
-    Render the Products management page in the Streamlit application.
-
-    This page provides a CRUD (Create, Read, Update, Delete) interface for
-    managing financial products in the portfolio. Users can add new products,
-    edit existing ones, and delete products (with referential integrity checks).
-
-    The page is organized into three main sections:
-
-    1. Add Product Form - Expander with form for creating new products
-    2. Products Table - Editable data editor with inline modifications
-    3. Advanced Deletion Tools - Guidance for cascade deletion scenarios
-
-    Parameters
-    ----------
-    session : Session
-        SQLModel database session for repository operations.
-
-    Returns
-    -------
-    None
-        This function renders UI components directly to Streamlit.
-
-    Notes
-    -----
-    Product creation validates:
-    - Name is mandatory and must be unique
-    - Type and unit are selected from predefined enums
-
-    Product deletion may fail if:
-    - Transactions reference the product (foreign key constraint)
-    - Valuations reference the product (foreign key constraint)
-
-    In case of deletion failure, users are guided to manually delete
-    related transactions/valuations first.
-
-    The editable table uses st.data_editor with a delete checkbox column.
-    Changes are applied in batch via a single "Apply" button.
-
-    Examples
-    --------
-    >>> from finance_tracker.web.db import get_session
-    >>> session = get_session()
-    >>> render(session)  # Renders the Products page in Streamlit
-    """
-    st.title("🏷️ Mes Produits")
-    st.caption("Créez, éditez et supprimez vos produits. (La suppression peut échouer si des transactions/valorisations existent.)")
+    """Render the Products management page in the Streamlit application."""
+    st.title(t("products.title"))
+    st.caption(t("products.caption"))
 
     # Initialize repositories for database operations
     product_repo = SQLModelProductRepository(session)
@@ -100,39 +35,35 @@ def render(session: Session) -> None:
     # SECTION 1: ADD PRODUCT FORM
     # ═══════════════════════════════════════════════════════════════════════════
 
-    with st.expander("➕ Ajouter un produit", expanded=False):
+    with st.expander(f"➕ {t('products.add_expander')}", expanded=False):
         with st.form("product_add_form", clear_on_submit=True):
             c1, c2 = st.columns([2, 2])
 
             with c1:
-                name = st.text_input("Nom *")
-                ptype = st.selectbox("Type", [e.value for e in ProductType])
-                unit = st.selectbox("Unité", [e.value for e in QuantityUnit])
-                risk = st.text_input("Niveau de risque (optionnel)", value="")
+                name = st.text_input(t("products.field_name"))
+                ptype = st.selectbox(t("products.field_type"), [e.value for e in ProductType])
+                unit = st.selectbox(t("products.field_unit"), [e.value for e in QuantityUnit])
+                risk = st.text_input(t("products.field_risk"), value="")
 
             with c2:
-                description = st.text_area("Description", height=80)
-                fees = st.text_area("Frais", height=80)
-                tax = st.text_area("Fiscalité", height=80)
+                description = st.text_area(t("products.field_description"), height=80)
+                fees = st.text_area(t("products.field_fees"), height=80)
+                tax = st.text_area(t("products.field_tax"), height=80)
 
-            submitted = st.form_submit_button("Créer", width="stretch")
+            submitted = st.form_submit_button(t("products.create_btn"), width="stretch")
 
             if submitted:
                 try:
-                    # Validate mandatory name field
-
                     if not name.strip():
-                        st.error("Le nom est obligatoire.")
+                        st.error(t("products.name_required"))
                         st.stop()
 
-                    # Check for duplicate product names
                     existing = product_repo.get_by_name(name.strip())
 
                     if existing:
-                        st.error(f"Un produit nommé '{name}' existe déjà.")
+                        st.error(t("products.name_duplicate").format(name=name))
                         st.stop()
 
-                    # Create new product with form data
                     p = Product(
                         name=name.strip(),
                         type=_enum_from_value(ProductType, ptype),
@@ -143,28 +74,25 @@ def render(session: Session) -> None:
                         tax_info=str(tax or "").strip(),
                         )
                     product_repo.create(p)
-                    st.success("✅ Produit créé.")
+                    st.success(t("products.created_success"))
                     st.rerun()
                 except Exception as e:
-                    st.error(f"❌ Erreur : {e}")
+                    st.error(t("products.error").format(e=e))
 
     st.markdown("---")
 
     # Retrieve all products for the editable table
     products = product_repo.get_all()
 
-    # Early return if no products exist
-
     if not products:
-        st.info("Aucun produit pour l'instant.")
-
+        st.info(t("products.empty"))
         return
 
     # ═══════════════════════════════════════════════════════════════════════════
     # SECTION 2: EDITABLE PRODUCTS TABLE
     # ═══════════════════════════════════════════════════════════════════════════
 
-    # Build rows for the data editor
+    delete_col = t("products.col_delete")
     rows = []
 
     for p in products:
@@ -179,40 +107,40 @@ def render(session: Session) -> None:
                 "fees_description": p.fees_description or "",
                 "tax_info": p.tax_info or "",
                 "created_at": p.created_at.date() if getattr(p, "created_at", None) else None,
-                "🗑️ Supprimer": False,  # Checkbox for deletion marking
+                delete_col: False,
                 }
             )
 
     df = pd.DataFrame(rows)
 
-    st.subheader("Liste des produits (éditable)")
+    st.subheader(t("products.list_title"))
     edited = st.data_editor(
         df,
         key="products_editor",
         hide_index=True,
         width="stretch",
-        num_rows="fixed",  # Prevent adding/deleting rows directly in editor
+        num_rows="fixed",
         column_config={
-            "id": st.column_config.NumberColumn("ID", disabled=True),
-            "name": st.column_config.TextColumn("Nom", required=True),
-            "type": st.column_config.SelectboxColumn("Type", options=[e.value for e in ProductType], required=True),
-            "quantity_unit": st.column_config.SelectboxColumn("Unité", options=[e.value for e in QuantityUnit], required=True),
-            "risk_level": st.column_config.TextColumn("Risque"),
-            "description": st.column_config.TextColumn("Description"),
-            "fees_description": st.column_config.TextColumn("Frais"),
-            "tax_info": st.column_config.TextColumn("Fiscalité"),
-            "created_at": st.column_config.DateColumn("Créé le", disabled=True, format="YYYY-MM-DD"),
-            "🗑️ Supprimer": st.column_config.CheckboxColumn("🗑️ Supprimer"),
+            "id": st.column_config.NumberColumn(t("products.col_id"), disabled=True),
+            "name": st.column_config.TextColumn(t("products.col_name"), required=True),
+            "type": st.column_config.SelectboxColumn(t("products.col_type"), options=[e.value for e in ProductType], required=True),
+            "quantity_unit": st.column_config.SelectboxColumn(t("products.col_unit"), options=[e.value for e in QuantityUnit], required=True),
+            "risk_level": st.column_config.TextColumn(t("products.col_risk")),
+            "description": st.column_config.TextColumn(t("products.col_description")),
+            "fees_description": st.column_config.TextColumn(t("products.col_fees")),
+            "tax_info": st.column_config.TextColumn(t("products.col_tax")),
+            "created_at": st.column_config.DateColumn(t("products.col_created_at"), disabled=True, format="YYYY-MM-DD"),
+            delete_col: st.column_config.CheckboxColumn(delete_col),
             },
         )
 
-    # ══════════════════════════════════════════════════���════════════════════════
-    # SECTION 3: ADVANCED DELETION TOOLS (Guidance)
+    # ═══════════════════════════════════════════════════════════════════════════
+    # SECTION 3: ADVANCED DELETION TOOLS
     # ═══════════════════════════════════════════════════════════════════════════
 
-    with st.expander("🧨 Outils suppression (avancé)", expanded=False):
-        st.write("Si une suppression de produit échoue, supprimez d'abord les transactions/valorisations associées.")
-        st.write("Astuce: utilisez la page Transactions / Valorisations, filtrez par produit, cochez 🗑️ puis appliquez.")
+    with st.expander(t("products.advanced_delete_expander"), expanded=False):
+        st.write(t("products.advanced_delete_help"))
+        st.write(t("products.advanced_delete_tip"))
 
     # ═══════════════════════════════════════════════════════════════════════════
     # SECTION 4: ACTION BUTTONS
@@ -221,50 +149,34 @@ def render(session: Session) -> None:
     c1, c2 = st.columns([2, 1])
 
     with c1:
-        if st.button("💾 Appliquer les changements", width="stretch"):
+        if st.button(t("products.apply_btn"), width="stretch"):
             try:
                 edited_rows = edited.to_dict(orient="records")
 
-                # ═══════════════════════════════════════════════════════════════
-                # VALIDATION: Check for empty and duplicate names
-                # ═══════════════════════════════════════════════════════════════
                 names = [
                     str(r.get("name", "")).strip()
-
                     for r in edited_rows
-
-                    if not bool(r.get("🗑️ Supprimer", False))
+                    if not bool(r.get(delete_col, False))
                     ]
 
                 if any(not n for n in names):
-                    raise ValueError("Tous les produits (non supprimés) doivent avoir un nom.")
+                    raise ValueError(t("products.name_empty_error"))
 
                 if len(set(names)) != len(names):
-                    raise ValueError("Les noms de produits doivent être uniques (au moins parmi les lignes non supprimées).")
-
-                # ═══════════════════════════════════════════════════════════════
-                # PROCESS EACH ROW: Delete or Update
-                # ═══════════════════════════════════════════════════════════════
+                    raise ValueError(t("products.name_unique_error"))
 
                 for r in edited_rows:
                     pid = r.get("id", None)
-
-                    # Skip rows without valid ID (should not happen in fixed rows mode)
 
                     if pid is None or (isinstance(pid, float) and pd.isna(pid)):
                         continue
 
                     pid = int(pid)
 
-                    # Handle deletion first (priority over updates)
-
-                    if bool(r.get("🗑️ Supprimer", False)):
-                        # May fail if child records exist (referential integrity)
+                    if bool(r.get(delete_col, False)):
                         product_repo.delete(pid)
-
                         continue
 
-                    # Handle updates for non-deleted rows
                     p = product_repo.get_by_id(pid)
 
                     if not p:
@@ -273,9 +185,8 @@ def render(session: Session) -> None:
                     new_name = str(r.get("name", "")).strip()
 
                     if not new_name:
-                        raise ValueError("Nom produit vide.")
+                        raise ValueError(t("products.name_required"))
 
-                    # Update product fields
                     p.name = new_name
                     p.type = _enum_from_value(ProductType, r["type"])
                     p.quantity_unit = _enum_from_value(QuantityUnit, r["quantity_unit"])
@@ -286,13 +197,11 @@ def render(session: Session) -> None:
 
                     product_repo.update(p)
 
-                st.success("✅ Changements appliqués.")
+                st.success(t("products.applied_success"))
                 st.rerun()
             except Exception as e:
-                st.error(f"❌ Erreur : {e}")
+                st.error(t("products.error").format(e=e))
 
     with c2:
-        # Reload button to discard edits and fetch fresh data
-
-        if st.button("↩️ Recharger depuis la DB", width="stretch"):
+        if st.button(t("products.reload_btn"), width="stretch"):
             st.rerun()

--- a/finance_tracker/web/views/simulation.py
+++ b/finance_tracker/web/views/simulation.py
@@ -83,6 +83,7 @@ from finance_tracker.services.simulation_service import (
     TaxBracket,
     TaxConfig,
     )
+from finance_tracker.i18n import t
 from finance_tracker.web.ui.formatters import to_decimal
 
 
@@ -184,13 +185,13 @@ _DEFAULT_RETURN_BY_KIND: dict[str, float] = {
 """Default annual return percentage by product category."""
 
 _KIND_HELP: dict[str, str] = {
-    "cash": "💡 Le cash reçoit les revenus et paie les dépenses. Aucun rendement applicable.",
-    "savings": "💡 Compte d'épargne : les intérêts sont capitalisés chaque période.",
-    "scpi": "💡 SCPI : le rendement est géré via le **taux de distribution** ci-dessous. Le rendement nominal est donc 0.",
-    "per": "💡 PER : les versements sont **déduits du revenu imposable** dans la limite du plafond défini dans les paramètres globaux.",
-    "fcpi": "💡 FCPI : **réduction d'impôt** sur les versements, capital bloqué pendant la durée définie.",
-    "other": "💡 Produit générique : rendement annuel capitalisé.",
-    "btc" : "💡 Bitcoin : les intérêts sont capitalisés chaque période.",
+    "cash": "Le cash reçoit les revenus et paie les dépenses. Aucun rendement applicable.",
+    "savings": "Compte d'épargne : les intérêts sont capitalisés chaque période.",
+    "scpi": "SCPI : le rendement est géré via le **taux de distribution** ci-dessous. Le rendement nominal est donc 0.",
+    "per": "PER : les versements sont **déduits du revenu imposable** dans la limite du plafond défini dans les paramètres globaux.",
+    "fcpi": "FCPI : **réduction d'impôt** sur les versements, capital bloqué pendant la durée définie.",
+    "other": "Produit générique : rendement annuel capitalisé.",
+    "btc" : "Bitcoin : les intérêts sont capitalisés chaque période.",
     }
 """Help text displayed for each product category in the form."""
 
@@ -214,7 +215,7 @@ _METRIC_LABELS: dict[str, str] = {
 _INFLATION_PROFILES: list[dict] = [
     {
         "key": "standard_cpi",
-        "label": "📊 Standard IPC — 2,0 %/an",
+        "label": "Standard IPC — 2,0 %/an",
         "rate": 2.0,
         "description": (
             "Utilise l'inflation officielle moyenne (IPC France). "
@@ -224,7 +225,7 @@ _INFLATION_PROFILES: list[dict] = [
     },
     {
         "key": "urban_tenant",
-        "label": "🏙️ Urbain locataire — 2,3 %/an",
+        "label": "Urbain locataire — 2,3 %/an",
         "rate": 2.3,
         "description": (
             "Recommandé si tu es locataire en ville et que ton loyer pèse lourd "
@@ -233,7 +234,7 @@ _INFLATION_PROFILES: list[dict] = [
     },
     {
         "key": "urban_owner",
-        "label": "🏠 Vie urbaine + projet immo — 3,0 %/an",
+        "label": "Vie urbaine + projet immo — 3,0 %/an",
         "rate": 3.0,
         "description": (
             "À choisir si ton objectif inclut l'accession à la propriété en ville. "
@@ -242,7 +243,7 @@ _INFLATION_PROFILES: list[dict] = [
     },
     {
         "key": "urban_sqm",
-        "label": "📐 Indexé m² de ville — 4,0 %/an",
+        "label": "Indexé m² de ville — 4,0 %/an",
         "rate": 4.0,
         "description": (
             "Profil patrimonial avancé : ton patrimoine financier suit le prix "
@@ -251,7 +252,7 @@ _INFLATION_PROFILES: list[dict] = [
     },
     {
         "key": "custom",
-        "label": "✏️ Personnalisé",
+        "label": "Personnalisé",
         "rate": None,
         "description": "Saisir manuellement le taux d'inflation annuel souhaité.",
     },
@@ -406,7 +407,7 @@ def _render_scpi_params(name: str) -> dict:
     st.markdown(
     "<div style='background:rgba(251, 140, 0, 0.15);border-left:4px solid #fb8c00;"
     "padding:8px 14px;border-radius:4px;margin:10px 0 6px 0'>"
-    "🏢 <strong>Paramètres SCPI</strong></div>",
+    "<strong>Paramètres SCPI</strong></div>",
     unsafe_allow_html=True,
     )
 
@@ -440,8 +441,8 @@ def _render_scpi_params(name: str) -> dict:
             "Fréquence des dividendes",
             ["monthly", "quarterly", "semiannual", "yearly"],
             format_func=lambda f: {
-                "monthly": "🗓️ Mensuelle", "quarterly": "🗓️ Trimestrielle",
-                "semiannual": "🗓️ Semestrielle", "yearly": "🗓️ Annuelle",
+                "monthly": "Mensuelle", "quarterly": "Trimestrielle",
+                "semiannual": "Semestrielle", "yearly": "Annuelle",
                 }[f],
             index=1,
             key=f"v3_scpi_freq_{name}",
@@ -499,7 +500,7 @@ def _render_fcpi_params(name: str) -> dict:
     st.markdown(
     "<div style='background:rgba(233, 30, 99, 0.15);border-left:4px solid #e91e63;"
     "padding:8px 14px;border-radius:4px;margin:10px 0 6px 0'>"
-    "📈 <strong>Paramètres FCPI</strong></div>",
+    "<strong>Paramètres FCPI</strong></div>",
     unsafe_allow_html=True,
     )
 
@@ -530,8 +531,8 @@ def _render_fcpi_params(name: str) -> dict:
             "Mode de sortie à échéance",
             ["principal", "full_value"],
             format_func=lambda m: (
-                "💰 Capital initial seulement" if m == "principal"
-                else "📊 Valeur totale du fonds"
+                "Capital initial seulement" if m == "principal"
+                else "Valeur totale du fonds"
                 ),
             index=0,
             key=f"v3_fcpi_exit_{name}",
@@ -569,7 +570,7 @@ def _render_inflation_selector() -> tuple[float, str]:
         - inflation_pct : float — the effective annual inflation rate (%)
         - profile_label : str — the label of the selected profile (for PDF)
     """
-    st.markdown("#### 📈 Profil d'inflation")
+    st.markdown(f"#### {t('simulation.section_inflation')}")
 
     profile_idx = st.selectbox(
         "Profil d'inflation",
@@ -597,7 +598,7 @@ def _render_inflation_selector() -> tuple[float, str]:
         inflation_pct = custom_rate
     else:
         inflation_pct = selected_profile["rate"]
-        st.caption(f"💡 {selected_profile['description']}")
+        st.caption(selected_profile["description"])
 
     return inflation_pct, selected_profile["label"]
 
@@ -625,7 +626,7 @@ def _render_kind_selectors(product_names: list[str]) -> None:
     the selected category across reruns. The default category is inferred
     from the product name (lowercase match).
     """
-    st.markdown("#### 🏷️ Catégories des produits")
+    st.markdown(f"#### {t('simulation.section_categories')}")
     st.caption(
         "Sélectionne la catégorie de chaque produit. "
         "Les paramètres spécifiques (SCPI, FCPI…) apparaissent automatiquement dans le formulaire ci-dessous."
@@ -710,7 +711,7 @@ def render(session: Session) -> None:
     >>> render(session)  # Renders the simulation page in Streamlit
     """
     _init_state()
-    st.header("🔮 Simulation Long Terme")
+    st.header(t("simulation.title"))
 
     # Load products from database
     product_repo = SQLModelProductRepository(session)
@@ -720,7 +721,7 @@ def render(session: Session) -> None:
     # Require at least one product
 
     if not product_names:
-        st.info("Ajoute au moins un produit dans '➕ Ajouter Produits' avant de simuler.")
+        st.info(t("simulation.no_product_warning"))
         st.stop()
 
     # Load current portfolio values as defaults
@@ -748,7 +749,7 @@ def render(session: Session) -> None:
         # ═══════════════════════════════════════════════════════════════════════
         # GLOBAL PARAMETERS
         # ═══════════════════════════════════════════════════════════════════════
-        st.markdown("### ⚙️ Paramètres globaux")
+        st.markdown(f"### {t('simulation.section_global_params')}")
         c1, c2, c3, c4 = st.columns(4)
 
         with c1:
@@ -799,7 +800,7 @@ def render(session: Session) -> None:
         # ═══════════════════════════════════════════════════════════════════════
         # TAX CONFIGURATION (Progressive Brackets)
         # ═══════════════════════════════════════════════════════════════════════
-        st.markdown("### 🧾 Fiscalité (barème progressif)")
+        st.markdown(f"### {t('simulation.section_tax')}")
         c1, c2 = st.columns(2)
         with c1:
             household_parts = st.number_input(
@@ -816,7 +817,7 @@ def render(session: Session) -> None:
             {"up_to": 177106, "rate_pct": 41.0},
             {"up_to": None, "rate_pct": 45.0},
             ]
-        st.caption("Tranches annuelles — laisse `up_to` vide pour la dernière tranche.")
+        st.caption(t("simulation.tax_caption"))
         df_brackets = st.data_editor(
             pd.DataFrame(default_brackets), width="stretch", num_rows="dynamic",
             )
@@ -832,7 +833,7 @@ def render(session: Session) -> None:
         # ═══════════════════════════════════════════════════════════════════════
         # PER DEDUCTION CAP
         # ═══════════════════════════════════════════════════════════════════════
-        st.markdown("### 📋 PER — Plafond déductible")
+        st.markdown(f"### {t('simulation.section_per')}")
         c1, c2, c3 = st.columns(3)
         with c1:
             per_rate_prev_income_pct = st.number_input("% du revenu N-1", 0.0, 50.0, 10.0, 0.5)
@@ -846,8 +847,8 @@ def render(session: Session) -> None:
         # ═══════════════════════════════════════════════════════════════════════
         # PER-PRODUCT PARAMETERS
         # ═══════════════════════════════════════════════════════════════════════
-        st.markdown("### 🗂️ Paramètres par produit")
-        st.caption("Seuls les paramètres pertinents s'affichent selon la catégorie définie ci-dessus.")
+        st.markdown(f"### {t('simulation.section_product_params')}")
+        st.caption(t("simulation.product_params_caption"))
 
         categories = list(_KIND_META.keys())
         sim_products: list[ProductSimConfig] = []
@@ -936,7 +937,7 @@ def render(session: Session) -> None:
                 else:
                     contrib_fixed = 0.0
                     contrib_pct_income = 0.0
-                    st.caption("ℹ️ Pour une SCPI, les apports sont définis via **'Parts achetées / an'** ci-dessous.")
+                    st.caption(t("simulation.scpi_caption"))
 
                 # ═══════════════════════════════════════════════════════════════
                 # TYPE-SPECIFIC PARAMETERS (SCPI, FCPI)
@@ -986,7 +987,7 @@ def render(session: Session) -> None:
         # Validation: require at least one cash product
 
         if not any(p.kind == "cash" for p in sim_products):
-            st.error("⚠️ Il faut au moins un produit de catégorie 'cash'.")
+            st.error(t("simulation.cash_required_error"))
 
         submitted = st.form_submit_button(
             "▶️ Lancer la simulation", type="primary", width="stretch",
@@ -1131,7 +1132,7 @@ def render(session: Session) -> None:
     # ── Persistent Results Display ─────────────────────────────────────────────
 
     if st.session_state.sim_df_long is None:
-        st.info("Soumets le formulaire pour lancer la simulation.")
+        st.info(t("simulation.submit_hint"))
 
         return
 
@@ -1143,14 +1144,14 @@ def render(session: Session) -> None:
     # SECTION 1: SUMMARY METRICS
     # ═══════════════════════════════════════════════════════════════════════════
     st.markdown("---")
-    st.subheader("📊 Résumé final")
+    st.subheader(t("simulation.section_summary"))
     c1, c2, c3, c4, c5 = st.columns(5)
     with c1:
-        st.metric("Valeur finale", f"{summary.get('final_value', 0):,.0f}€".replace(",", " "))
+        st.metric(t("simulation.metric_final_value"), f"{summary.get('final_value', 0):,.0f}€".replace(",", " "))
     with c2:
-        st.metric("Valeur réelle (inflation)", f"{summary.get('final_value_real', 0):,.0f}€".replace(",", " "))
+        st.metric(t("simulation.metric_real_value"), f"{summary.get('final_value_real', 0):,.0f}€".replace(",", " "))
     with c3:
-        st.metric("Investi cumulé (hors cash)", f"{summary.get('final_invested', 0):,.0f}€".replace(",", " "))
+        st.metric(t("simulation.metric_invested"), f"{summary.get('final_invested', 0):,.0f}€".replace(",", " "))
     with c4:
         st.metric(
             "Gains (hors cash)",
@@ -1158,13 +1159,13 @@ def render(session: Session) -> None:
             delta=f"{summary.get('gains_pct', 0):.1f}%",
             )
     with c5:
-        st.metric("Impôt dû N à payer N+1", f"{summary.get('tax_due_next_year', 0):,.0f}€".replace(",", " "))
+        st.metric(t("simulation.metric_tax_due"), f"{summary.get('tax_due_next_year', 0):,.0f}€".replace(",", " "))
 
     # ═══════════════════════════════════════════════════════════════════════════
     # SECTION 2: DATA TABLES
     # ═══════════════════════════════════════════════════════════════════════════
-    st.subheader("📋 Tableaux de données")
-    tab1, tab2 = st.tabs(["Par période", "Par produit (long)"])
+    st.subheader(t("simulation.section_tables"))
+    tab1, tab2 = st.tabs([t("simulation.tab_by_period"), t("simulation.tab_by_product")])
     with tab1:
         st.dataframe(df_period, width="stretch")
     with tab2:
@@ -1173,7 +1174,7 @@ def render(session: Session) -> None:
     # ═══════════════════════════════════════════════════════════════════════════
     # SECTION 3: CHARTS
     # ═══════════════════════════════════════════════════════════════════════════
-    st.subheader("📈 Graphiques")
+    st.subheader(t("simulation.section_charts"))
     selected_metrics = st.multiselect(
         "Métriques à afficher",
         options=list(_METRIC_LABELS.keys()),
@@ -1243,7 +1244,7 @@ def render(session: Session) -> None:
         # Check if PDF needs generation
 
         if pdf_cache_key not in st.session_state or st.session_state.get("sim_pdf_needs_update", True):
-            if st.button("⚙️ Préparer le rapport PDF", width="stretch"):
+            if st.button(t("simulation.prepare_pdf"), width="stretch"):
                 with st.spinner("⏳ Génération du rapport PDF avec graphiques en cours (cela peut prendre quelques secondes)..."):
                     try:
                         config_params = st.session_state.sim_config_params or {}
@@ -1259,12 +1260,12 @@ def render(session: Session) -> None:
                         st.session_state["sim_pdf_needs_update"] = False
                         st.rerun()  # Refresh to show download button
                     except Exception as e:
-                        st.error(f"Erreur lors de la génération du PDF : {e}")
+                        st.error(t("simulation.pdf_error").format(e=e))
 
         # PDF is ready for download
         else:
             st.download_button(
-                "⬇️ Télécharger le PDF",
+                "⬇️ Télécharger le PDF",  # intentional: download affordance
                 data=st.session_state[pdf_cache_key],
                 file_name=f"simulation_report_{datetime.now().strftime('%Y%m%d_%H%M%S')}.pdf",
                 mime="application/pdf",

--- a/finance_tracker/web/views/transactions.py
+++ b/finance_tracker/web/views/transactions.py
@@ -1,46 +1,5 @@
 """
 transactions.py — Streamlit UI for transaction management.
-
-This module provides the transaction management interface for Finance Tracker.
-Users can add, edit, and delete financial transactions through an editable
-data table with filtering and sorting capabilities.
-
-The module handles multiple transaction types:
-- DEPOSIT: Cash inflow to the portfolio
-- WITHDRAW: Cash outflow from the portfolio
-- BUY: Asset purchase (reduces cash, increases position)
-- SELL: Asset sale (increases cash, decreases position)
-- DISTRIBUTION: Dividend or coupon received
-- FEE: Fees paid
-
-Special handling is provided for Bitcoin transactions, where quantities
-are stored and displayed in satoshis (1 BTC = 100,000,000 satoshis).
-
-Key Features
-------------
-- Add transaction form with dynamic quantity labels for Bitcoin
-- Editable data table with inline modification
-- Filtering by product and transaction type
-- Sorting by date or ID (ascending/descending)
-- Batch apply changes with validation
-- Automatic satoshi rounding for Bitcoin quantities
-
-Module Constants
-----------------
-SATS_PER_BTC : int
-    Number of satoshis in one Bitcoin (100,000,000).
-
-Examples
---------
->>> from finance_tracker.web.views.transactions import render
->>> from sqlmodel import Session
->>> session = Session(engine)
->>> render(session)  # Renders the transactions page in Streamlit
-
-See Also
---------
-finance_tracker.domain.enums.TransactionType : Transaction type enum
-finance_tracker.repositories.sqlmodel_repo.SQLModelTransactionRepository : Data access
 """
 
 import streamlit as st
@@ -51,6 +10,7 @@ from sqlmodel import Session
 
 from finance_tracker.domain.enums import TransactionType
 from finance_tracker.domain.models import Transaction
+from finance_tracker.i18n import t
 from finance_tracker.repositories.sqlmodel_repo import (
     SQLModelProductRepository,
     SQLModelTransactionRepository,
@@ -58,151 +18,56 @@ from finance_tracker.repositories.sqlmodel_repo import (
 from finance_tracker.web.ui.formatters import to_decimal
 
 SATS_PER_BTC = 100_000_000
-"""Number of satoshis in one Bitcoin (used for display/formatting)."""
 
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# HELPER FUNCTIONS
-# ═══════════════════════════════════════════════════════════════════════════════
 
 def _enum_from_value(enum_cls, value: str):
-    """
-    Retrieve an enum member by its string value.
-
-    This function performs a reverse lookup to find an enum member
-    whose value attribute matches the provided string.
-
-    Parameters
-    ----------
-    enum_cls : type
-        The enum class to search in (e.g., TransactionType, ProductType).
-    value : str
-        The string value to match against enum member values.
-
-    Returns
-    -------
-    Enum
-        The enum member with matching value.
-
-    Raises
-    ------
-    ValueError
-        If no enum member has the specified value.
-
-    Examples
-    --------
-    >>> from finance_tracker.domain.enums import TransactionType
-    >>> _enum_from_value(TransactionType, "BUY")
-    <TransactionType.BUY: 'BUY'>
-    >>> _enum_from_value(TransactionType, "INVALID")
-    ValueError: Valeur enum inconnue: 'INVALID'
-    """
-
     for e in enum_cls:
         if e.value == value:
             return e
     raise ValueError(f"Valeur enum inconnue: {value!r}")
 
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# MAIN RENDER FUNCTION
-# ═══════════════════════════════════════════════════════════════════════════════
-
 def render(session: Session) -> None:
-    """
-    Render the Transactions management page in the Streamlit application.
+    """Render the Transactions management page in the Streamlit application."""
+    st.title(t("transactions.title"))
+    st.caption(t("transactions.caption"))
 
-    This page provides a CRUD interface for financial transactions with
-    an editable data table. Users can add new transactions via a form,
-    and modify or delete existing transactions inline.
-
-    The page is organized into two main sections:
-
-    1. Add Transaction Form - Expander with product selector and form fields
-    2. Transaction List - Editable data table with filters and sort options
-
-    Parameters
-    ----------
-    session : Session
-        SQLModel database session for repository operations.
-
-    Returns
-    -------
-    None
-        This function renders UI components directly to Streamlit.
-
-    Notes
-    -----
-    Bitcoin Handling:
-    - Bitcoin quantities are displayed and edited in satoshis (integers)
-    - The form adapts labels and step values for Bitcoin products
-    - Quantities are rounded to integers before saving for Bitcoin
-
-    Transaction Types:
-    - DEPOSIT: Cash inflow (positive for invested amount calculation)
-    - WITHDRAW: Cash outflow (negative for invested amount calculation)
-    - BUY: Asset purchase (negative for invested amount, increases position)
-    - SELL: Asset sale (positive for invested amount, decreases position)
-    - DISTRIBUTION: Dividend/coupon received (positive for invested amount)
-    - FEE: Fees paid (negative for invested amount calculation)
-
-    The editable table uses st.data_editor with fixed rows (no inline addition).
-    Changes are applied in batch via the "Appliquer les changements" button.
-
-    Examples
-    --------
-    >>> from finance_tracker.web.db import get_session
-    >>> session = get_session()
-    >>> render(session)  # Renders the transactions page in Streamlit
-    """
-    st.title("💸 Mes Transactions")
-    st.caption("Ajout, modification et suppression directement depuis la liste.")
-
-    # Initialize repositories
     product_repo = SQLModelProductRepository(session)
     tx_repo = SQLModelTransactionRepository(session)
 
-    # Load products for selectors
     products = product_repo.get_all()
     product_names = [p.name for p in products]
     product_by_name = {p.name: p for p in products}
     product_by_id = {p.id: p for p in products if p.id is not None}
 
-    # Early return if no products exist
-
     if not products:
-        st.info("Aucun produit. Créez d'abord un produit pour pouvoir ajouter des transactions.")
-
+        st.info(t("transactions.no_products"))
         return
 
     # ═══════════════════════════════════════════════════════════════════════════
     # SECTION 1: ADD TRANSACTION FORM
     # ═══════════════════════════════════════════════════════════════════════════
-    with st.expander("➕ Ajouter une transaction", expanded=False):
-        # Product selector placed OUTSIDE the form for dynamic field adaptation
-        # This allows the quantity field to change based on selected product
-        add_product_name = st.selectbox("Produit", product_names, key="tx_add_product")
+    with st.expander(f"➕ {t('transactions.add_expander')}", expanded=False):
+        add_product_name = st.selectbox(t("transactions.field_product"), product_names, key="tx_add_product")
 
-        # Adapt quantity field for Bitcoin (satoshis) vs other products
         is_btc = add_product_name.lower() == "bitcoin"
-        qty_label = "Quantité (en Satoshis)" if is_btc else "Quantité (Parts / Unités)"
+        qty_label = t("transactions.field_qty_sats") if is_btc else t("transactions.field_qty_units")
         qty_step = 100_000.0 if is_btc else 0.01
         qty_format = "%d" if is_btc else "%.2f"
-        qty_help = "Rappel: 1 BTC = 100 000 000 Sats" if is_btc else ""
+        qty_help = t("transactions.field_qty_help_btc") if is_btc else ""
 
         with st.form("tx_add_form", clear_on_submit=True):
             c1, c2, c3 = st.columns([2, 2, 3])
             with c1:
-                add_type = st.selectbox("Type", [e.value for e in TransactionType], key="tx_add_type")
-                add_date = st.date_input("Date", value=date.today(), key="tx_add_date")
+                add_type = st.selectbox(t("transactions.field_type"), [e.value for e in TransactionType], key="tx_add_type")
+                add_date = st.date_input(t("transactions.field_date"), value=date.today(), key="tx_add_date")
             with c2:
-                add_amount = st.number_input("Montant EUR (optionnel)", value=0.0, step=0.01, format="%.2f", key="tx_add_amount")
-                # Quantity field adapts based on product selector above
+                add_amount = st.number_input(t("transactions.field_amount"), value=0.0, step=0.01, format="%.2f", key="tx_add_amount")
                 add_quantity = st.number_input(qty_label, value=0.0, step=qty_step, format=qty_format, help=qty_help, key="tx_add_qty")
             with c3:
-                add_note = st.text_input("Note", value="", key="tx_add_note")
+                add_note = st.text_input(t("transactions.field_note"), value="", key="tx_add_note")
 
-            submitted = st.form_submit_button("Ajouter", width="stretch")
+            submitted = st.form_submit_button(t("transactions.add_btn"), width="stretch")
 
             if submitted:
                 try:
@@ -211,7 +76,6 @@ def render(session: Session) -> None:
                     if not p or p.id is None:
                         st.stop()
 
-                    # For Bitcoin, store raw satoshis (no decimal conversion)
                     final_qty = float(add_quantity)
 
                     tx = Transaction(
@@ -223,10 +87,10 @@ def render(session: Session) -> None:
                         note=add_note.strip(),
                         )
                     tx_repo.create(tx)
-                    st.success("✅ Transaction ajoutée.")
+                    st.success(t("transactions.added_success"))
                     st.rerun()
                 except Exception as e:
-                    st.error(f"❌ Erreur : {e}")
+                    st.error(t("transactions.error").format(e=e))
 
     st.markdown("---")
 
@@ -234,85 +98,75 @@ def render(session: Session) -> None:
     # SECTION 2: TRANSACTION LIST WITH FILTERS AND EDITABLE TABLE
     # ═══════════════════════════════════════════════════════════════════════════
 
-    # Filter controls
+    filter_all = t("transactions.filter_all")
+    sort_date_desc = t("transactions.sort_date_desc")
+    sort_date_asc = t("transactions.sort_date_asc")
+    sort_id_desc = t("transactions.sort_id_desc")
+
     f1, f2, f3 = st.columns([2, 2, 2])
     with f1:
-        filter_product = st.selectbox("Filtrer produit", ["Tous"] + product_names, index=0)
+        filter_product = st.selectbox(t("transactions.filter_product"), [filter_all] + product_names, index=0)
     with f2:
-        filter_type = st.selectbox("Filtrer type", ["Tous"] + [e.value for e in TransactionType], index=0)
+        filter_type = st.selectbox(t("transactions.filter_type"), [filter_all] + [e.value for e in TransactionType], index=0)
     with f3:
-        sort_mode = st.selectbox("Tri", ["Date décroissante", "Date croissante", "ID décroissant"], index=0)
+        sort_mode = st.selectbox(t("transactions.sort_label"), [sort_date_desc, sort_date_asc, sort_id_desc], index=0)
 
-    # Load and filter transactions
     txs = tx_repo.get_all()
 
-    # Apply product filter
-
-    if filter_product != "Tous":
+    if filter_product != filter_all:
         pid = product_by_name[filter_product].id
-        txs = [t for t in txs if t.product_id == pid]
+        txs = [tx for tx in txs if tx.product_id == pid]
 
-    # Apply type filter
+    if filter_type != filter_all:
+        txs = [tx for tx in txs if tx.type.value == filter_type]
 
-    if filter_type != "Tous":
-        txs = [t for t in txs if t.type.value == filter_type]
+    if sort_mode == sort_date_asc:
+        txs = sorted(txs, key=lambda tx: tx.date)
+    elif sort_mode == sort_id_desc:
+        txs = sorted(txs, key=lambda tx: (tx.id or 0), reverse=True)
+    else:
+        txs = sorted(txs, key=lambda tx: tx.date, reverse=True)
 
-    # Apply sorting
-
-    if sort_mode == "Date croissante":
-        txs = sorted(txs, key=lambda t: t.date)
-    elif sort_mode == "ID décroissant":
-        txs = sorted(txs, key=lambda t: (t.id or 0), reverse=True)
-    else:  # Date décroissante (default)
-        txs = sorted(txs, key=lambda t: t.date, reverse=True)
-
-    # Build rows for data editor
+    delete_col = t("transactions.col_delete")
     rows = []
 
-    for t in txs:
-        p = product_by_id.get(t.product_id)
+    for tx in txs:
+        p = product_by_id.get(tx.product_id)
         rows.append({
-            "id": t.id,
-            "date": t.date.date(),
-            "produit": p.name if p else f"#{t.product_id}",
-            "type": t.type.value,
-            "montant_eur": float(t.amount_eur) if t.amount_eur is not None else 0.0,
-            "quantite": float(t.quantity) if t.quantity is not None else 0.0,
-            "note": t.note or "",
-            "🗑️ Supprimer": False,
+            "id": tx.id,
+            "date": tx.date.date(),
+            "produit": p.name if p else f"#{tx.product_id}",
+            "type": tx.type.value,
+            "montant_eur": float(tx.amount_eur) if tx.amount_eur is not None else 0.0,
+            "quantite": float(tx.quantity) if tx.quantity is not None else 0.0,
+            "note": tx.note or "",
+            delete_col: False,
             })
 
-    # Early return if no transactions match filters
-
     if not rows:
-        st.info("Aucune transaction pour ce filtre.")
-
+        st.info(t("transactions.empty_filter"))
         return
 
     df = pd.DataFrame(rows)
 
-    st.subheader("Historique (éditable)")
+    st.subheader(t("transactions.list_title"))
+    st.info(t("transactions.btc_qty_info"))
 
-    # Informational message about Bitcoin quantities
-    st.info("ℹ️ Les quantités concernant Bitcoin sont affichées et enregistrées en **Satoshis** (nombres entiers). Les autres produits restent en unités standards.")
-
-    # Editable data table
     edited = st.data_editor(
         df,
         key="tx_editor",
         hide_index=True,
         width="stretch",
-        num_rows="fixed",  # Prevent inline row addition
+        num_rows="fixed",
         column_config={
-            "id": st.column_config.NumberColumn("ID", disabled=True),
-            "date": st.column_config.DateColumn("Date", format="YYYY-MM-DD"),
-            "produit": st.column_config.SelectboxColumn("Produit", options=product_names, required=True),
-            "type": st.column_config.SelectboxColumn("Type", options=[e.value for e in TransactionType], required=True),
-            "montant_eur": st.column_config.NumberColumn("Montant EUR", min_value=0.0, step=0.01, format="%.2f"),
-            # Step at 0.01 to handle all products (SCPI need decimals, Bitcoin handled separately)
-            "quantite": st.column_config.NumberColumn("Quantité (Sats ou Unités)", min_value=0.0, step=0.01, format="%.2f"),
-            "note": st.column_config.TextColumn("Note"),
-            "🗑️ Supprimer": st.column_config.CheckboxColumn("🗑️ Supprimer"),
+            "id": st.column_config.NumberColumn(t("transactions.col_id"), disabled=True),
+            "date": st.column_config.DateColumn(t("transactions.col_date"), format="YYYY-MM-DD"),
+            "produit": st.column_config.SelectboxColumn(t("transactions.col_product"), options=product_names, required=True),
+            "type": st.column_config.SelectboxColumn(t("transactions.col_type"), options=[e.value for e in TransactionType], required=True),
+            "montant_eur": st.column_config.NumberColumn(t("transactions.col_amount"), min_value=0.0, step=0.01, format="%.2f"),
+            "quantite": st.column_config.NumberColumn(t("transactions.col_qty"), min_value=0.0, step=0.01, format="%.2f"),
+            "note": st.column_config.TextColumn(t("transactions.col_note")),
+            delete_col: st.column_config.CheckboxColumn(delete_col),
             },
         )
 
@@ -322,47 +176,37 @@ def render(session: Session) -> None:
     c1, c2 = st.columns([2, 1])
 
     with c1:
-        if st.button("💾 Appliquer les changements", width="stretch"):
+        if st.button(t("transactions.apply_btn"), width="stretch"):
             try:
                 edited_rows = edited.to_dict(orient="records")
 
                 for r in edited_rows:
                     tx_id = r.get("id", None)
 
-                    # Skip rows without valid ID (should not happen in fixed rows mode)
-
                     if tx_id is None or (isinstance(tx_id, float) and pd.isna(tx_id)):
                         continue
 
-                    # Handle deletion first (priority over updates)
-
-                    if bool(r.get("🗑️ Supprimer", False)):
+                    if bool(r.get(delete_col, False)):
                         tx_repo.delete(int(tx_id))
-
                         continue
 
-                    # Handle updates for non-deleted rows
                     tx = tx_repo.get_by_id(int(tx_id))
 
                     if not tx:
                         continue
 
-                    # Validate and resolve product
                     prod_name = r["produit"]
                     p = product_by_name.get(prod_name)
 
                     if not p or p.id is None:
-                        raise ValueError(f"Produit invalide: {prod_name!r}")
+                        raise ValueError(t("transactions.invalid_product").format(name=prod_name))
 
-                    # Update transaction fields
                     tx.product_id = p.id
                     tx.date = datetime.combine(r["date"], datetime.min.time())
                     tx.type = _enum_from_value(TransactionType, r["type"])
 
                     amount = float(r.get("montant_eur") or 0.0)
                     raw_qty = float(r.get("quantite") or 0.0)
-
-                    # Force integer rounding for Bitcoin (pure satoshis)
 
                     if prod_name.lower() == "bitcoin":
                         raw_qty = float(int(raw_qty))
@@ -373,13 +217,11 @@ def render(session: Session) -> None:
 
                     tx_repo.update(tx)
 
-                st.success("✅ Changements appliqués.")
+                st.success(t("transactions.applied_success"))
                 st.rerun()
             except Exception as e:
-                st.error(f"❌ Erreur : {e}")
+                st.error(t("transactions.error").format(e=e))
 
     with c2:
-        # Reload button to discard edits and fetch fresh data
-
-        if st.button("↩️ Recharger depuis la DB", width="stretch"):
+        if st.button(t("transactions.reload_btn"), width="stretch"):
             st.rerun()

--- a/finance_tracker/web/views/valuations.py
+++ b/finance_tracker/web/views/valuations.py
@@ -1,52 +1,5 @@
 """
 valuations.py — Streamlit UI for valuation management.
-
-This module provides the valuation management interface for Finance Tracker.
-Users can add, edit, and delete valuation snapshots through an editable
-data table with filtering and sorting capabilities.
-
-A valuation (or snapshot) captures the value of a product at a specific
-point in time. This enables:
-- Tracking portfolio value evolution over time
-- Calculating unrealized gains/losses
-- Computing performance metrics (MWRR, returns)
-- Generating historical charts and reports
-
-Key Features
-------------
-- Add valuation form with dynamic labels for Bitcoin (BTC price vs unit price)
-- Editable data table with inline modification
-- Filtering by product
-- Sorting by date or ID (ascending/descending)
-- Batch apply changes with validation
-- Automatic timestamp handling
-
-Valuation Fields
-----------------
-total_value_eur : Decimal
-    Total value of the position in EUR (required, must be > 0).
-unit_price_eur : Decimal, optional
-    Price per unit/share in EUR. For Bitcoin, this represents the price
-    of one full BTC (not satoshi price).
-date : datetime
-    Snapshot date (stored as datetime at midnight for consistency).
-
-Notes
------
-For Bitcoin products, the unit_price_eur field displays as "Prix d'un BTC plein (EUR)"
-to clarify that users should enter the full Bitcoin price, not the satoshi price.
-
-Examples
---------
->>> from finance_tracker.web.views.valuations import render
->>> from sqlmodel import Session
->>> session = Session(engine)
->>> render(session)  # Renders the valuations page in Streamlit
-
-See Also
---------
-finance_tracker.domain.models.Valuation : Valuation model definition
-finance_tracker.repositories.sqlmodel_repo.SQLModelValuationRepository : Data access
 """
 
 import streamlit as st
@@ -56,6 +9,7 @@ from datetime import datetime, date
 from sqlmodel import Session
 
 from finance_tracker.domain.models import Valuation
+from finance_tracker.i18n import t
 from finance_tracker.repositories.sqlmodel_repo import (
     SQLModelProductRepository,
     SQLModelValuationRepository,
@@ -63,73 +17,18 @@ from finance_tracker.repositories.sqlmodel_repo import (
 from finance_tracker.web.ui.formatters import to_decimal
 
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# MAIN RENDER FUNCTION
-# ═══════════════════════════════════════════════════════════════════════════════
-
 def render(session: Session) -> None:
-    """
-    Render the Valuations management page in the Streamlit application.
+    """Render the Valuations management page in the Streamlit application."""
+    st.title(t("valuations.title"))
+    st.caption(t("valuations.caption"))
 
-    This page provides a CRUD interface for valuation snapshots with
-    an editable data table. Users can add new valuations via a form,
-    and modify or delete existing valuations inline.
-
-    The page is organized into two main sections:
-
-    1. Add Valuation Form - Expander with product selector and form fields
-    2. Valuation List - Editable data table with filters and sort options
-
-    Parameters
-    ----------
-    session : Session
-        SQLModel database session for repository operations.
-
-    Returns
-    -------
-    None
-        This function renders UI components directly to Streamlit.
-
-    Notes
-    -----
-    Valuations are snapshots that capture:
-    - The total value of a position at a specific date
-    - Optionally, the unit price (useful for tracking price evolution)
-
-    For Bitcoin products:
-    - The unit price field label changes to "Prix d'un BTC plein (EUR)"
-    - Users should enter the full Bitcoin price, not satoshi price
-    - This allows tracking BTC price evolution alongside total value
-
-    Validation:
-    - Total value must be strictly positive (> 0)
-    - Unit price is optional but must be positive if provided
-    - Date is required and defaults to today
-
-    The editable table uses st.data_editor with fixed rows (no inline addition).
-    Changes are applied in batch via the "Appliquer les changements" button.
-
-    Examples
-    --------
-    >>> from finance_tracker.web.db import get_session
-    >>> session = get_session()
-    >>> render(session)  # Renders the valuations page in Streamlit
-    """
-    st.title("📈 Mes Valorisations")
-    st.caption("Snapshots de valeur : ajout, édition et suppression depuis une table unique.")
-
-    # Initialize repositories
     product_repo = SQLModelProductRepository(session)
     val_repo = SQLModelValuationRepository(session)
 
-    # Load products for selectors
     products = product_repo.get_all()
 
-    # Early return if no products exist
-
     if not products:
-        st.info("Aucun produit. Créez un produit avant d'ajouter des valorisations.")
-
+        st.info(t("valuations.no_products"))
         return
 
     product_names = [p.name for p in products]
@@ -139,26 +38,22 @@ def render(session: Session) -> None:
     # ═══════════════════════════════════════════════════════════════════════════
     # SECTION 1: ADD VALUATION FORM
     # ═══════════════════════════════════════════════════════════════════════════
-    with st.expander("➕ Ajouter une valorisation", expanded=False):
-        # Product selector placed OUTSIDE the form for dynamic field adaptation
-        # This allows the unit price label to change based on selected product
-        add_product_name = st.selectbox("Produit", product_names, key="val_add_product")
+    with st.expander(f"➕ {t('valuations.add_expander')}", expanded=False):
+        add_product_name = st.selectbox(t("valuations.field_product"), product_names, key="val_add_product")
 
-        # Adapt unit price label for Bitcoin (full BTC price) vs other products
         is_btc = add_product_name.lower() == "bitcoin"
 
         with st.form("val_add_form", clear_on_submit=True):
             c1, c2 = st.columns([2, 2])
             with c1:
-                add_date = st.date_input("Date", value=date.today(), key="val_add_date")
+                add_date = st.date_input(t("valuations.field_date"), value=date.today(), key="val_add_date")
             with c2:
-                add_total = st.number_input("Valeur totale EUR", value=0.0, step=0.01, format="%.2f", key="val_add_total")
+                add_total = st.number_input(t("valuations.field_total"), value=0.0, step=0.01, format="%.2f", key="val_add_total")
 
-                # Label changes to be explicit for Bitcoin pricing
-                unit_label = "Prix d'un BTC plein (EUR)" if is_btc else "Prix unitaire (EUR, optionnel)"
+                unit_label = t("valuations.field_unit_price_btc") if is_btc else t("valuations.field_unit_price")
                 add_unit = st.number_input(unit_label, value=0.0, step=0.01, format="%.2f", key="val_add_unit")
 
-            submitted = st.form_submit_button("Ajouter", width="stretch")
+            submitted = st.form_submit_button(t("valuations.add_btn"), width="stretch")
 
             if submitted:
                 try:
@@ -167,10 +62,8 @@ def render(session: Session) -> None:
                     if not p or p.id is None:
                         st.stop()
 
-                    # Validate that total value is positive
-
                     if add_total <= 0:
-                        st.error("La valeur totale doit être > 0.")
+                        st.error(t("valuations.total_positive_error"))
                         st.stop()
 
                     val = Valuation(
@@ -180,10 +73,10 @@ def render(session: Session) -> None:
                         unit_price_eur=to_decimal(add_unit) if add_unit and add_unit > 0 else None,
                         )
                     val_repo.create(val)
-                    st.success("✅ Valorisation ajoutée.")
+                    st.success(t("valuations.added_success"))
                     st.rerun()
                 except Exception as e:
-                    st.error(f"❌ Erreur : {e}")
+                    st.error(t("valuations.error").format(e=e))
 
     st.markdown("---")
 
@@ -191,32 +84,31 @@ def render(session: Session) -> None:
     # SECTION 2: VALUATION LIST WITH FILTERS AND EDITABLE TABLE
     # ═══════════════════════════════════════════════════════════════════════════
 
-    # Filter controls
+    filter_all = t("valuations.filter_all")
+    sort_date_desc = t("valuations.sort_date_desc")
+    sort_date_asc = t("valuations.sort_date_asc")
+    sort_id_desc = t("valuations.sort_id_desc")
+
     f1, f2 = st.columns([2, 2])
     with f1:
-        filter_product = st.selectbox("Filtrer produit", ["Tous"] + product_names, index=0)
+        filter_product = st.selectbox(t("valuations.filter_product"), [filter_all] + product_names, index=0)
     with f2:
-        sort_mode = st.selectbox("Tri", ["Date décroissante", "Date croissante", "ID décroissant"], index=0)
+        sort_mode = st.selectbox(t("valuations.sort_label"), [sort_date_desc, sort_date_asc, sort_id_desc], index=0)
 
-    # Load and filter valuations
     vals = val_repo.get_all()
 
-    # Apply product filter
-
-    if filter_product != "Tous":
+    if filter_product != filter_all:
         pid = product_by_name[filter_product].id
         vals = [v for v in vals if v.product_id == pid]
 
-    # Apply sorting
-
-    if sort_mode == "Date croissante":
+    if sort_mode == sort_date_asc:
         vals = sorted(vals, key=lambda v: v.date)
-    elif sort_mode == "ID décroissant":
+    elif sort_mode == sort_id_desc:
         vals = sorted(vals, key=lambda v: (v.id or 0), reverse=True)
-    else:  # Date décroissante (default)
+    else:
         vals = sorted(vals, key=lambda v: v.date, reverse=True)
 
-    # Build rows for data editor
+    delete_col = t("valuations.col_delete")
     rows = []
 
     for v in vals:
@@ -228,35 +120,31 @@ def render(session: Session) -> None:
                 "produit": p.name if p else f"#{v.product_id}",
                 "valeur_totale_eur": float(v.total_value_eur),
                 "prix_unitaire_eur": float(v.unit_price_eur) if v.unit_price_eur is not None else 0.0,
-                "🗑️ Supprimer": False,
+                delete_col: False,
                 }
             )
 
-    # Early return if no valuations match filters
-
     if not rows:
-        st.info("Aucune valorisation pour ce filtre.")
-
+        st.info(t("valuations.empty_filter"))
         return
 
     df = pd.DataFrame(rows)
 
-    st.subheader("Historique (éditable)")
+    st.subheader(t("valuations.list_title"))
 
-    # Editable data table
     edited = st.data_editor(
         df,
         key="val_editor",
         hide_index=True,
         width="stretch",
-        num_rows="fixed",  # Prevent inline row addition
+        num_rows="fixed",
         column_config={
-            "id": st.column_config.NumberColumn("ID", disabled=True),
-            "date": st.column_config.DateColumn("Date", format="YYYY-MM-DD"),
-            "produit": st.column_config.SelectboxColumn("Produit", options=product_names, required=True),
-            "valeur_totale_eur": st.column_config.NumberColumn("Valeur totale EUR", min_value=0.0, step=0.01, format="%.2f"),
-            "prix_unitaire_eur": st.column_config.NumberColumn("Prix unitaire EUR", min_value=0.0, step=0.01, format="%.2f"),
-            "🗑️ Supprimer": st.column_config.CheckboxColumn("🗑️ Supprimer"),
+            "id": st.column_config.NumberColumn(t("valuations.col_id"), disabled=True),
+            "date": st.column_config.DateColumn(t("valuations.col_date"), format="YYYY-MM-DD"),
+            "produit": st.column_config.SelectboxColumn(t("valuations.col_product"), options=product_names, required=True),
+            "valeur_totale_eur": st.column_config.NumberColumn(t("valuations.col_total"), min_value=0.0, step=0.01, format="%.2f"),
+            "prix_unitaire_eur": st.column_config.NumberColumn(t("valuations.col_unit_price"), min_value=0.0, step=0.01, format="%.2f"),
+            delete_col: st.column_config.CheckboxColumn(delete_col),
             },
         )
 
@@ -266,48 +154,37 @@ def render(session: Session) -> None:
     c1, c2 = st.columns([2, 1])
 
     with c1:
-        if st.button("💾 Appliquer les changements", width="stretch"):
+        if st.button(t("valuations.apply_btn"), width="stretch"):
             try:
                 edited_rows = edited.to_dict(orient="records")
 
                 for r in edited_rows:
                     val_id = r.get("id", None)
 
-                    # Skip rows without valid ID (should not happen in fixed rows mode)
-
                     if val_id is None or (isinstance(val_id, float) and pd.isna(val_id)):
                         continue
 
-                    # Handle deletion first (priority over updates)
-
-                    if bool(r.get("🗑️ Supprimer", False)):
+                    if bool(r.get(delete_col, False)):
                         val_repo.delete(int(val_id))
-
                         continue
 
-                    # Handle updates for non-deleted rows
                     v = val_repo.get_by_id(int(val_id))
 
                     if not v:
                         continue
 
-                    # Validate and resolve product
                     prod_name = r["produit"]
                     p = product_by_name.get(prod_name)
 
                     if not p or p.id is None:
-                        raise ValueError(f"Produit invalide: {prod_name!r}")
+                        raise ValueError(t("valuations.invalid_product").format(name=prod_name))
 
-                    # Extract and validate values
                     total = float(r.get("valeur_totale_eur") or 0.0)
                     unit = float(r.get("prix_unitaire_eur") or 0.0)
 
-                    # Validate that total value is positive
-
                     if total <= 0:
-                        raise ValueError("La valeur totale doit être > 0.")
+                        raise ValueError(t("valuations.total_positive_update_error"))
 
-                    # Update valuation fields
                     v.product_id = p.id
                     v.date = datetime.combine(r["date"], datetime.min.time())
                     v.total_value_eur = to_decimal(total)
@@ -315,13 +192,11 @@ def render(session: Session) -> None:
 
                     val_repo.update(v)
 
-                st.success("✅ Changements appliqués.")
+                st.success(t("valuations.applied_success"))
                 st.rerun()
             except Exception as e:
-                st.error(f"❌ Erreur : {e}")
+                st.error(t("valuations.error").format(e=e))
 
     with c2:
-        # Reload button to discard edits and fetch fresh data
-
-        if st.button("↩️ Recharger depuis la DB", width="stretch"):
+        if st.button(t("valuations.reload_btn"), width="stretch"):
             st.rerun()


### PR DESCRIPTION
## Summary

- **Closes #3** — internationalization (FR/EN) with automatic browser language detection and manual override

## What changed

### i18n infrastructure (`finance_tracker/i18n/`)
- `__init__.py` — `t(key)` helper that reads the active language from `st.session_state["lang"]`, falls back to FR
- `fr.py` / `en.py` — complete translation dictionaries covering all views (~150 keys)
- Language is detected automatically from the `Accept-Language` HTTP header via `st.context.headers` (available in Streamlit 1.37+)
- A sidebar selectbox allows manual override; changing it triggers an immediate `st.rerun()`

### Navigation (`navigation.py`)
- `Page` dataclass gains a stable `id: str` field — the radio widget now stores the page ID, not the translated label, so the selected page survives language switches

### App (`app.py`)
- Language selector rendered first in sidebar (above DB management)
- All sidebar strings replaced with `t()` calls

### Views (all 7)
- Every user-visible string replaced with `t()` calls
- Emojis removed from: page titles, section headers (`###`), metric labels, button labels, documentation tabs, SCPI/FCPI form labels, inflation profile labels, FAQ expanders

## Test plan

- [ ] Launch app in FR — verify all labels display in French
- [ ] Switch to EN via sidebar selector — verify full UI switches to English, selected page stays the same
- [ ] Open app with browser set to English — verify auto-detection picks EN
- [ ] Generate PDF report — verify it renders without error
- [ ] Run simulation end-to-end — verify all metrics and tab labels are correct
- [ ] `python -m pytest tests/` passes (14/14)
