### PR TITLE
fix: remove redundant doc button, enhance donation button, add Inflation doc tab

### DIFF
--- a/finance_tracker/i18n/en.py
+++ b/finance_tracker/i18n/en.py
@@ -293,6 +293,25 @@ STRINGS: dict[str, str] = {
     "documentation.calculs_key_metrics": "Key Indicators",
     "documentation.calculs_compound": "Compound Interest",
     "documentation.calculs_bitcoin_title": "₿ Special Case: Bitcoin",
+    # Inflation tab
+    "documentation.tab_inflation": "Inflation",
+    "documentation.inflation_title": "📊 Configurable Inflation",
+    "documentation.inflation_intro": (
+        "The long-term simulator offers four predefined inflation profiles, "
+        "plus a custom option."
+    ),
+    "documentation.inflation_profiles_title": "Inflation Profiles",
+    "documentation.inflation_how_title": "How it works?",
+    "documentation.inflation_how": (
+        "In the simulator, replaces the simple *Annual Inflation (%)* field with a profile "
+        "selector. The corresponding rate is automatically applied to all projections "
+        "and appears in the exported PDF report."
+    ),
+    "documentation.inflation_sources": (
+        "**Sources:** INSEE IPC long-term series, "
+        "rent reference indices ([IRL — ANIL](https://www.anil.org/outils/indices-et-plafonds/tableau-de-lirl/)) "
+        "and [IGEDD/Friggit](https://www.cgedd.fr/prix-immobilier-friggit.pdf) work on real estate price evolution."
+    ),
     # Interface tab
     "documentation.interface_title": "Web Interface Guide",
     "documentation.interface_intro": "Complete page-by-page guide to the Streamlit interface.",

--- a/finance_tracker/i18n/fr.py
+++ b/finance_tracker/i18n/fr.py
@@ -293,6 +293,25 @@ STRINGS: dict[str, str] = {
     "documentation.calculs_key_metrics": "Indicateurs Clés",
     "documentation.calculs_compound": "Intérêts Composés",
     "documentation.calculs_bitcoin_title": "₿ Cas Spécial : Bitcoin",
+    # Inflation tab
+    "documentation.tab_inflation": "Inflation",
+    "documentation.inflation_title": "📊 Inflation Paramétrable",
+    "documentation.inflation_intro": (
+        "Le simulateur long terme propose quatre profils d'inflation prédéfinis, "
+        "plus une option personnalisée."
+    ),
+    "documentation.inflation_profiles_title": "Profils d'Inflation",
+    "documentation.inflation_how_title": "Comment ça marche ?",
+    "documentation.inflation_how": (
+        "Dans le simulateur, remplace le simple champ *Inflation annuelle (%)* par un sélecteur "
+        "de profil. Le taux correspondant est appliqué automatiquement à toutes les projections "
+        "et apparaît dans le rapport PDF exporté."
+    ),
+    "documentation.inflation_sources": (
+        "**Sources :** séries longues [INSEE IPC](https://www.insee.fr/fr/statistiques/4268033), "
+        "indices de référence des loyers ([IRL — ANIL](https://www.anil.org/outils/indices-et-plafonds/tableau-de-lirl/)) "
+        "et travaux [IGEDD/Friggit](https://www.cgedd.fr/prix-immobilier-friggit.pdf) sur l'évolution des prix immobiliers."
+    ),
     # Interface tab
     "documentation.interface_title": "Guide Interface Web",
     "documentation.interface_intro": "Guide complet page par page de l'interface Streamlit.",

--- a/finance_tracker/web/app.py
+++ b/finance_tracker/web/app.py
@@ -149,17 +149,25 @@ selected_id = st.sidebar.radio(
     options=[p.id for p in pages],
     format_func=lambda pid: next(p.label for p in pages if p.id == pid),
 )
-st.sidebar.link_button(
-    t("app.doc_link_btn"),
-    f"{GITHUB_BASE_URL}/README.md",
-    )
-st.sidebar.markdown("---")
-
 # donation button
-st.sidebar.link_button(
-    t("app.donate_btn"),
-    "https://html-preview.github.io/?url=https://github.com/SKOHscripts/donate.github.io/blob/main/donate%2Fredirect.html"
-    )
+donate_url = "https://html-preview.github.io/?url=https://github.com/SKOHscripts/donate.github.io/blob/main/donate%2Fredirect.html"
+st.sidebar.markdown(f"""
+<div style="margin: 0.5rem 0;">
+  <a href="{donate_url}" target="_blank" style="
+    display: block;
+    background: linear-gradient(135deg, #c67c2d 0%, #e8943a 100%);
+    color: white;
+    text-align: center;
+    padding: 0.6rem 1rem;
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: bold;
+    font-size: 0.9rem;
+    border: 1px solid #f0a545;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+  ">{t("app.donate_btn")}</a>
+</div>
+""", unsafe_allow_html=True)
 st.sidebar.markdown("---")
 
 st.sidebar.info(f"**{t('app.sidebar_version')}**\n\n{t('app.sidebar_description')}")

--- a/finance_tracker/web/views/documentation.py
+++ b/finance_tracker/web/views/documentation.py
@@ -255,6 +255,43 @@ def _render_tab_calculs() -> None:
         st.markdown(content)
 
 
+def _render_tab_inflation() -> None:
+    """Render the inflation profiles documentation tab."""
+
+    st.markdown(f"## {t('documentation.inflation_title')}")
+    st.markdown(t("documentation.inflation_intro"))
+
+    st.divider()
+
+    st.markdown(f"### {t('documentation.inflation_profiles_title')}")
+
+    st.markdown("""
+| Profil | Taux | Plage indicative | Cas d'usage |
+|---|---|---|---|
+| **Standard IPC** (défaut) | 2,0 %/an | 1,7–2,0 % | Neutraliser l'inflation officielle sur les dépenses courantes |
+| **Urbain locataire** | 2,3 %/an | 2,2–2,5 % | Locataire en ville avec un loyer significatif |
+| **Vie urbaine + projet immo** | 3,0 %/an | 2,7–3,2 % | Utilisateur visant l'accession à la propriété en ville |
+| **Indexé m² de ville** | 4,0 %/an | 3,5–5,0 % | Suivi du patrimoine au prix du m² immobilier urbain |
+| **Personnalisé** | libre | — | Saisir manuellement tout autre taux |
+""")
+
+    st.divider()
+
+    st.markdown(f"### {t('documentation.inflation_how_title')}")
+    st.markdown(t("documentation.inflation_how"))
+
+    st.divider()
+
+    st.markdown(t("documentation.inflation_sources"))
+
+    st.divider()
+
+    st.markdown(t("documentation.full_doc_link").format(
+        title="Inflation Paramétrable",
+        url=f"{GITHUB_BASE_URL}/README.md#-inflation-param%C3%A9trable",
+    ))
+
+
 def _render_tab_interface() -> None:
     """Render the web interface documentation tab."""
 
@@ -563,13 +600,14 @@ def render(session: Session) -> None:
         t("documentation.tab_home"),
         t("documentation.tab_concepts"),
         t("documentation.tab_calculs"),
+        t("documentation.tab_inflation"),
         t("documentation.tab_interface"),
         t("documentation.tab_database"),
         t("documentation.tab_install"),
         t("documentation.tab_help"),
         ])
 
-    tab_home, tab_concepts, tab_calculs, tab_interface, tab_database, tab_install, tab_help = tabs
+    tab_home, tab_concepts, tab_calculs, tab_inflation, tab_interface, tab_database, tab_install, tab_help = tabs
 
     with tab_home:
         _render_tab_home()
@@ -579,6 +617,9 @@ def render(session: Session) -> None:
 
     with tab_calculs:
         _render_tab_calculs()
+
+    with tab_inflation:
+        _render_tab_inflation()
 
     with tab_interface:
         _render_tab_interface()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **#20** — Supprime le bouton `link_button("Documentation (README)")` de la sidebar (redondant avec l'onglet Documentation de la navigation)
- **#21** — Remplace le bouton de don gris par un bouton HTML stylé orange/brun avec dégradé et ombre, plus visible et engageant
- **#24** — Ajoute un nouvel onglet **Inflation** dans la page Documentation, positionné entre "Calculs" et "Interface Web", avec : tableau des 4 profils prédéfinis + option personnalisée, sources (INSEE/IRL/Friggit), explication du fonctionnement, et lien vers la section README correspondante

## Fichiers modifiés

- `finance_tracker/web/app.py` — #20 + #21
- `finance_tracker/web/views/documentation.py` — #24
- `finance_tracker/i18n/fr.py` — clés de traduction FR pour l'onglet Inflation
- `finance_tracker/i18n/en.py` — clés de traduction EN pour l'onglet Inflation

## Test plan

- [ ] Vérifier que le bouton "📖 Documentation (README)" n'apparaît plus dans la sidebar
- [ ] Vérifier que le bouton de don est affiché en orange/brun avec un style HTML amélioré
- [ ] Vérifier que l'onglet "Inflation" est présent entre "Calculs" et "Interface Web" dans la page Documentation
- [ ] Vérifier le contenu : tableau des profils, sources, lien vers README
- [ ] Tester en FR et EN (changement de langue)

Closes #20, #21, #24

https://claude.ai/code/session_01JUSk7v4sPtY73cp1iFUq2Q
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUSk7v4sPtY73cp1iFUq2Q)_