### PR TITLE
Reorganize navigation: merge valorisations & bitcoin into dashboard

### DIFF
--- a/finance_tracker/i18n/en.py
+++ b/finance_tracker/i18n/en.py
@@ -143,7 +143,7 @@ STRINGS: dict[str, str] = {
     "products.col_delete": "🗑️ Delete",
     "products.advanced_delete_expander": "Deletion tools (advanced)",
     "products.advanced_delete_help": "If product deletion fails, delete associated transactions/valuations first.",
-    "products.advanced_delete_tip": "Tip: use the Transactions / Valuations page, filter by product, check 🗑️ and apply.",
+    "products.advanced_delete_tip": "Tip: use the Transactions page or the Dashboard (product detail) to delete associated valuations.",
     "products.apply_btn": "Apply changes",
     "products.name_empty_error": "All products (not deleted) must have a name.",
     "products.name_unique_error": "Product names must be unique (at least among non-deleted rows).",
@@ -264,8 +264,7 @@ STRINGS: dict[str, str] = {
         "|------|--------|------|\n"
         "| 1 | Create your products | 🏷️ **My Products** |\n"
         "| 2 | Add transactions | 💸 **My Transactions** |\n"
-        "| 3 | Update valuations | 📈 **My Valuations** |\n"
-        "| 4 | View the dashboard | 📊 **Dashboard** |"
+        "| 3 | Update valuations & view performance | 📊 **Dashboard** |"
     ),
     "documentation.home_explore_title": "Explore the Documentation",
     "documentation.home_explore_text": "Use the **tabs above** to access the different documentation sections.",
@@ -347,7 +346,7 @@ STRINGS: dict[str, str] = {
     "documentation.help_tips_title": "Usage Tips",
     "documentation.help_tips": (
         "**Tip #1:** Start by reading **Concepts** to understand the 3 pillars of the system.\n\n"
-        "**Tip #2:** Update your **📈 Valuations** regularly (monthly minimum).\n\n"
+        "**Tip #2:** Update your valuations regularly from the **📊 Dashboard** (monthly minimum).\n\n"
         "**Tip #3:** Use the **🔮 Simulator** to plan your future investments.\n\n"
         "**Tip #4:** Back up your database regularly via the sidebar."
     ),

--- a/finance_tracker/i18n/fr.py
+++ b/finance_tracker/i18n/fr.py
@@ -143,7 +143,7 @@ STRINGS: dict[str, str] = {
     "products.col_delete": "🗑️ Supprimer",
     "products.advanced_delete_expander": "Outils suppression (avancé)",
     "products.advanced_delete_help": "Si une suppression de produit échoue, supprimez d'abord les transactions/valorisations associées.",
-    "products.advanced_delete_tip": "Astuce : utilisez la page Transactions / Valorisations, filtrez par produit, cochez 🗑️ puis appliquez.",
+    "products.advanced_delete_tip": "Astuce : utilisez la page Transactions ou le Tableau de Bord (détail du produit) pour supprimer les valorisations associées.",
     "products.apply_btn": "Appliquer les changements",
     "products.name_empty_error": "Tous les produits (non supprimés) doivent avoir un nom.",
     "products.name_unique_error": "Les noms de produits doivent être uniques (au moins parmi les lignes non supprimées).",
@@ -264,8 +264,7 @@ STRINGS: dict[str, str] = {
         "|-------|--------|------|\n"
         "| 1 | Créer vos produits | 🏷️ **Mes Produits** |\n"
         "| 2 | Ajouter des transactions | 💸 **Mes Transactions** |\n"
-        "| 3 | Mettre à jour les valorisations | 📈 **Mes Valorisations** |\n"
-        "| 4 | Consulter le tableau de bord | 📊 **Tableau de Bord** |"
+        "| 3 | Mettre à jour les valorisations & consulter les performances | 📊 **Tableau de Bord** |"
     ),
     "documentation.home_explore_title": "Explorer la Documentation",
     "documentation.home_explore_text": "Utilisez les **onglets ci-dessus** pour accéder aux différentes sections de documentation.",
@@ -347,7 +346,7 @@ STRINGS: dict[str, str] = {
     "documentation.help_tips_title": "Conseils d'Utilisation",
     "documentation.help_tips": (
         "**Conseil #1 :** Commencez par lire les **Concepts** pour comprendre les 3 piliers du système.\n\n"
-        "**Conseil #2 :** Mettez à jour vos **📈 Valorisations** régulièrement (mensuellement minimum).\n\n"
+        "**Conseil #2 :** Mettez à jour vos valorisations régulièrement depuis le **📊 Tableau de Bord** (mensuellement minimum).\n\n"
         "**Conseil #3 :** Utilisez le **🔮 Simulateur** pour planifier vos investissements futurs.\n\n"
         "**Conseil #4 :** Sauvegardez régulièrement votre base de données via la sidebar."
     ),

--- a/finance_tracker/web/navigation.py
+++ b/finance_tracker/web/navigation.py
@@ -20,10 +20,8 @@ def build_pages() -> list[Page]:
     # Lazy imports avoid circular dependencies since views may import navigation
     from finance_tracker.web.views.dashboard import render as dashboard_render
     from finance_tracker.web.views.simulation import render as simulation_render
-    from finance_tracker.web.views.bitcoin import render as bitcoin_render
     from finance_tracker.web.views.products import render as products_render
     from finance_tracker.web.views.transactions import render as transactions_render
-    from finance_tracker.web.views.valuations import render as valuations_render
     from finance_tracker.web.views.documentation import render as documentation_render
     from finance_tracker.i18n import t
 
@@ -38,8 +36,4 @@ def build_pages() -> list[Page]:
         # Data management
         Page("products", t("nav.products"), products_render),
         Page("transactions", t("nav.transactions"), transactions_render),
-        Page("valuations", t("nav.valuations"), valuations_render),
-
-        # Specialized tools
-        Page("bitcoin", t("nav.bitcoin"), bitcoin_render),
         ]

--- a/finance_tracker/web/views/dashboard.py
+++ b/finance_tracker/web/views/dashboard.py
@@ -201,7 +201,7 @@ def _render_bitcoin_expander(details: dict, product_id: int, service: "Dashboard
         st.dataframe(pd.DataFrame(rows_btc), hide_index=True, use_container_width=True)
 
 
-def _render_generic_expander(details: dict) -> None:
+def _render_generic_expander(details: dict, product_id: int, service: "DashboardService") -> None:
     """Render the generic product detail section inside an expander."""
     # Mini KPI row
     k1, k2, k3, k4 = st.columns(4)
@@ -268,19 +268,95 @@ def _render_generic_expander(details: dict) -> None:
             unsafe_allow_html=True,
         )
 
-    # Recent valuations table
-    recent = list(reversed(details["history"]))[:8]
-    if recent:
-        table_rows = []
-        for v in recent:
-            row = {
-                "Date": v["date"].strftime("%d/%m/%Y") if hasattr(v["date"], "strftime") else str(v["date"]),
-                "Valeur (€)": f"{v['total_value_eur']:,.2f}".replace(",", " "),
-            }
-            if v.get("unit_price_eur"):
-                row["Prix unitaire (€)"] = f"{v['unit_price_eur']:,.2f}".replace(",", " ")
-            table_rows.append(row)
-        st.dataframe(pd.DataFrame(table_rows), hide_index=True, use_container_width=True)
+    st.markdown("---")
+
+    # ── Add valuation form ──────────────────────────────────────────────────────
+    st.markdown(f"##### ➕ {t('valuations.add_expander')}")
+    with st.form(f"val_add_{product_id}", clear_on_submit=True):
+        fc1, fc2, fc3 = st.columns(3)
+        with fc1:
+            add_date = st.date_input(t("valuations.field_date"), value=date.today())
+        with fc2:
+            add_total = st.number_input(t("valuations.field_total"), value=0.0, step=0.01, format="%.2f")
+        with fc3:
+            add_unit = st.number_input(t("valuations.field_unit_price"), value=0.0, step=0.01, format="%.2f")
+        if st.form_submit_button(t("valuations.add_btn"), type="primary", width="stretch"):
+            if add_total <= 0:
+                st.error(t("valuations.total_positive_error"))
+            else:
+                try:
+                    val = Valuation(
+                        product_id=product_id,
+                        date=datetime.combine(add_date, datetime.min.time()),
+                        total_value_eur=to_decimal(add_total),
+                        unit_price_eur=to_decimal(add_unit) if add_unit > 0 else None,
+                    )
+                    service.valuation_repo.create(val)
+                    st.success(t("valuations.added_success"))
+                    st.rerun()
+                except Exception as e:
+                    st.error(t("valuations.error").format(e=e))
+
+    # ── Editable valuations table ───────────────────────────────────────────────
+    product_vals = sorted(
+        service.valuation_repo.get_by_product_id(product_id),
+        key=lambda v: v.date, reverse=True,
+    )
+    if product_vals:
+        delete_col = t("valuations.col_delete")
+        rows = []
+        for v in product_vals:
+            rows.append({
+                "id": v.id,
+                "date": v.date.date() if hasattr(v.date, "date") else v.date,
+                "valeur_totale_eur": float(v.total_value_eur),
+                "prix_unitaire_eur": float(v.unit_price_eur) if v.unit_price_eur is not None else 0.0,
+                delete_col: False,
+            })
+        df_vals = pd.DataFrame(rows)
+        edited = st.data_editor(
+            df_vals,
+            key=f"val_editor_{product_id}",
+            hide_index=True,
+            width="stretch",
+            num_rows="fixed",
+            column_config={
+                "id": st.column_config.NumberColumn(t("valuations.col_id"), disabled=True),
+                "date": st.column_config.DateColumn(t("valuations.col_date"), format="YYYY-MM-DD"),
+                "valeur_totale_eur": st.column_config.NumberColumn(t("valuations.col_total"), min_value=0.0, step=0.01, format="%.2f"),
+                "prix_unitaire_eur": st.column_config.NumberColumn(t("valuations.col_unit_price"), min_value=0.0, step=0.01, format="%.2f"),
+                delete_col: st.column_config.CheckboxColumn(delete_col),
+            },
+        )
+        ca, cb = st.columns([2, 1])
+        with ca:
+            if st.button(t("valuations.apply_btn"), key=f"val_apply_{product_id}", width="stretch"):
+                try:
+                    for r in edited.to_dict(orient="records"):
+                        val_id = r.get("id")
+                        if val_id is None or (isinstance(val_id, float) and pd.isna(val_id)):
+                            continue
+                        if bool(r.get(delete_col, False)):
+                            service.valuation_repo.delete(int(val_id))
+                            continue
+                        v = service.valuation_repo.get_by_id(int(val_id))
+                        if not v:
+                            continue
+                        total = float(r.get("valeur_totale_eur") or 0.0)
+                        unit = float(r.get("prix_unitaire_eur") or 0.0)
+                        if total <= 0:
+                            raise ValueError(t("valuations.total_positive_update_error"))
+                        v.date = datetime.combine(r["date"], datetime.min.time())
+                        v.total_value_eur = to_decimal(total)
+                        v.unit_price_eur = to_decimal(unit) if unit > 0 else None
+                        service.valuation_repo.update(v)
+                    st.success(t("valuations.applied_success"))
+                    st.rerun()
+                except Exception as e:
+                    st.error(t("valuations.error").format(e=e))
+        with cb:
+            if st.button(t("valuations.reload_btn"), key=f"val_reload_{product_id}", width="stretch"):
+                st.rerun()
 
 
 def render(session: Session) -> None:
@@ -439,7 +515,7 @@ def render(session: Session) -> None:
             if details["type"] == "BITCOIN":
                 _render_bitcoin_expander(details, product_id, service)
             else:
-                _render_generic_expander(details)
+                _render_generic_expander(details, product_id, service)
 
     st.markdown("---")
 

--- a/finance_tracker/web/views/documentation.py
+++ b/finance_tracker/web/views/documentation.py
@@ -90,6 +90,11 @@ def _render_tab_home() -> None:
 
     st.divider()
 
+    st.markdown(f"### {t('documentation.help_tips_title')}")
+    st.info(t("documentation.help_tips"))
+
+    st.divider()
+
     st.markdown(f"### {t('documentation.home_explore_title')}")
     st.markdown(t("documentation.home_explore_text"))
     st.info(t("documentation.home_tip"))
@@ -303,12 +308,10 @@ def _render_tab_interface() -> None:
     st.markdown(f"### {t('documentation.interface_architecture')}")
 
     pages_data = {
-        "📊 Tableau de Bord": "Vue globale du portefeuille, répartition, graphiques temporels",
+        "📊 Tableau de Bord": "Vue globale, répartition, graphiques et gestion des valorisations par produit",
         "🔮 Simulation Long Terme": "Projections avec intérêts composés, scénarios multi-hypothèses",
         "🏷️ Mes Produits": "CRUD des produits financiers (création, édition, suppression)",
         "💸 Mes Transactions": "Historique et saisie des mouvements (DEPOSIT, BUY, SELL, etc.)",
-        "📈 Mes Valorisations": "Mise à jour des prix unitaires par produit",
-        "₿ Espace Bitcoin": "Prix temps réel (CoinGecko), historique, conversions",
         }
 
     for page, desc in pages_data.items():
@@ -329,10 +332,8 @@ def _render_tab_interface() -> None:
        └─ DEPOSIT (versement initial)
        └─ BUY (achat de parts)
 
-    3. 📈 Mes Valorisations
-       └─ Mettre à jour le prix unitaire
-
-    4. 📊 Tableau de Bord
+    3. 📊 Tableau de Bord
+       └─ Ajouter / modifier les valorisations par produit
        └─ Consulter la performance
     ```
     """)
@@ -534,10 +535,10 @@ def _render_tab_help() -> None:
         """),
 
         ("Comment mettre à jour la valeur de mon portefeuille?", """
-1. Allez à **📈 Mes Valorisations**
-2. Cliquez "Ajouter une valorisation"
-3. Sélectionnez le produit
-4. Entrez la nouvelle valeur unitaire
+1. Allez au **📊 Tableau de Bord**
+2. Ouvrez le détail du produit concerné
+3. Cliquez "Ajouter une valorisation"
+4. Entrez la valeur totale et le prix unitaire
 5. Validez
 
 Les gains latents seront calculés automatiquement!
@@ -552,8 +553,8 @@ Pour restaurer: utilisez "Importer votre sauvegarde"
         """),
 
         ("Le prix Bitcoin se met-il à jour automatiquement?", """
-Oui! L'**₿ Espace Bitcoin** utilise l'API CoinGecko pour récupérer
-le prix en temps réel. Les mises à jour sont automatiques.
+Oui! Le **📊 Tableau de Bord** (section Bitcoin) utilise l'API CoinGecko
+pour récupérer le prix en temps réel via le bouton "Actualiser le cours".
         """),
         ]
 
@@ -582,10 +583,6 @@ le prix en temps réel. Les mises à jour sont automatiques.
         st.markdown(t("documentation.help_resources_readme").format(url=GITHUB_BASE_URL))
         st.markdown(t("documentation.help_resources_roadmap").format(url=DOCS_GITHUB_URL))
 
-    st.divider()
-
-    st.markdown(f"### {t('documentation.help_tips_title')}")
-    st.info(t("documentation.help_tips"))
 
 
 def render(session: Session) -> None:


### PR DESCRIPTION

## Summary

- **Conseils d'utilisation déplacés** : la section "Conseils d'utilisation" de l'onglet Aide apparaît maintenant juste après le "Démarrage rapide" dans l'onglet Accueil de la documentation
- **"Espace Bitcoin" supprimé de la navigation** : la page de redirection n'apparaît plus dans la sidebar (les fonctionnalités Bitcoin restent dans le Tableau de Bord → Détail par produit)
- **"Mes Valorisations" supprimé de la navigation** : le formulaire d'ajout et le tableau éditables sont désormais intégrés directement dans chaque expander produit du dashboard (pour les produits génériques), avec bouton Ajouter, tableau éditable, et boutons Appliquer/Recharger
- **Documentation mise à jour** : quickstart, workflow, FAQ et conseils pointent maintenant vers le Tableau de Bord au lieu des pages supprimées

## Test plan

- [ ] Vérifier que la sidebar ne contient plus "Espace Bitcoin" ni "Mes Valorisations"
- [ ] Vérifier que l'onglet Accueil de la doc affiche les conseils d'utilisation après le démarrage rapide
- [ ] Vérifier que l'onglet Aide ne contient plus les conseils (déjà dans Accueil)
- [ ] Ouvrir un produit générique dans le dashboard → vérifier la présence du formulaire d'ajout et du tableau éditables
- [ ] Ajouter une valorisation depuis le dashboard et vérifier qu'elle apparaît dans le tableau
- [ ] Modifier/supprimer une valorisation via le tableau éditables et appliquer
- [ ] Vérifier que le produit Bitcoin n'est pas affecté (son expander est inchangé)
