### PR TITLE
ci: modernise workflows — pip caching, parallel jobs, coverage

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,24 +1,25 @@
 name: Pylint
 
-on: [push]
+on:
+  push:
+  pull_request:
+    branches: ["main"]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11"]
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.11"
+        cache: "pip"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install "pylint>=3.3"
         pip install -e ".[dev]"
-    - name: Analysing the code with pylint
+    - name: Analyse with pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,39 +1,49 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
 name: Python application
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
 
 jobs:
-  build:
-
+  lint:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
+        cache: "pip"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8
         pip install -e ".[dev]"
-    - name: Lint with flake8
+    - name: Flake8 — block on syntax errors and undefined names
       run: |
-        # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+    - name: Flake8 — style warnings (non-blocking)
+      run: |
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: "pip"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
     - name: Test with pytest
       run: |
-        pytest
+        pytest --cov=finance_tracker --cov-report=term-missing


### PR DESCRIPTION
## Changements

### `pylint.yml`
- `setup-python@v3` → `v5` avec `cache: "pip"` (installs 2-3× plus rapides grâce au cache des wheels)
- Suppression de la `matrix` inutile (un seul Python, pas besoin d'une matrice)
- Trigger ajouté sur `pull_request` vers `main` (avant : seulement sur push)

### `python-app.yml`
- `setup-python@v3` → `v5` avec `cache: "pip"`
- **Deux jobs parallèles** `lint` et `test` au lieu d'un seul `build` séquentiel — on voit immédiatement si c'est le lint ou les tests qui cassent, et les deux s'exécutent en parallèle
- `flake8` déplacé dans le job `lint`, séparé du job `test`
- `pytest` avec `--cov=finance_tracker --cov-report=term-missing` — affiche la couverture de code dans les logs CI (pytest-cov est déjà dans les dev deps)

## Résultat

| Avant | Après |
|-------|-------|
| 1 job séquentiel (lint → test) | 2 jobs parallèles |
| Pas de cache pip | Cache pip activé |
| setup-python v3 (obsolète) | setup-python v5 |
| Pas de couverture | Couverture affichée |

https://claude.ai/code/session_01VTBKKYLiAQ6mDPdmVhpRAT

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTBKKYLiAQ6mDPdmVhpRAT)_