### PR TITLE
fix: sidebar hint en CSS pur (cause: testid disparu en Streamlit 1.57)

### DIFF
--- a/finance_tracker/web/app.py
+++ b/finance_tracker/web/app.py
@@ -11,9 +11,7 @@ support for SCPIs, cryptocurrencies like Bitcoin, savings accounts, and other
 financial assets.
 """
 import html as _html
-import json
 import streamlit as st
-import streamlit.components.v1 as st_components
 import os
 from finance_tracker.web.db import get_session, get_db_path, get_engine
 from finance_tracker.web.navigation import build_pages
@@ -119,71 +117,34 @@ def render_db_manager():
 
             st.rerun()
 
-        # Animated ↖ arrow hinting at the sidebar toggle after 20 s of inactivity.
+        # Animated ↖ arrow pointing at the sidebar toggle, shown only while the
+        # sidebar is collapsed and after 20 s of inactivity. Pure CSS — no JS, no
+        # iframe (st.components.v1.html is deprecated and its timers die on every
+        # Streamlit re-render, which is why earlier JS versions never appeared).
         #
-        # Architecture note: both st.html() and st.components.v1.html() render
-        # inside an iframe. Code in an iframe cannot reliably set long-lived timers
-        # because the iframe may be destroyed on Streamlit re-renders. The solution
-        # is to inject a <script> element into window.parent.document.head: inline
-        # scripts execute immediately and synchronously in the MAIN window context,
-        # so their timers survive re-renders. The iframe script runs once (guarded
-        # by window.parent._sbHintInit) and delegates everything else to the
-        # main-context script.
-        _hint_inner = json.dumps(
-            '<div class="_a">&#x2196;</div>'
-            f'<div class="_t">{_html.escape(t("app.sidebar_hint"))}</div>'
+        # In Streamlit 1.57 the sidebar <section data-testid="stSidebar"> carries
+        # aria-expanded="false" when collapsed and "true" when open. The :has()
+        # selector below shows the hint only when collapsed, so it disappears the
+        # instant the user opens the sidebar. animation-delay handles the 20 s wait.
+        hint_label = _html.escape(t("app.sidebar_hint"))
+        st.markdown(
+            "<style>"
+            "#_sb_hint{position:fixed;top:68px;left:44px;z-index:99999;display:none;"
+            "flex-direction:column;align-items:flex-start;gap:3px;pointer-events:none;opacity:0}"
+            'body:has(section[data-testid="stSidebar"][aria-expanded="false"]) #_sb_hint{'
+            "display:flex;animation:sb-reveal .4s ease-out 20s forwards}"
+            "@keyframes sb-reveal{to{opacity:1}}"
+            "#_sb_hint ._a{font-size:22px;color:#0088ff;line-height:1;"
+            "animation:sb-bounce 1.1s ease-in-out infinite}"
+            "@keyframes sb-bounce{0%,100%{transform:translate(0,0)}50%{transform:translate(-9px,-9px)}}"
+            "#_sb_hint ._t{background:#0088ff;color:#fff;padding:3px 9px;border-radius:10px;"
+            "font-size:11px;white-space:nowrap;font-family:sans-serif;font-weight:600;"
+            "box-shadow:0 2px 6px rgba(0,136,255,.4)}"
+            "</style>"
+            '<div id="_sb_hint"><div class="_a">&#x2196;</div>'
+            f'<div class="_t">{hint_label}</div></div>',
+            unsafe_allow_html=True,
         )
-        # Plain Python string — no f-string, so { } are JS literals, no escaping.
-        _main_script = (
-            "(function(){"
-            "if(window._sbRunInit)return;"
-            "window._sbRunInit=true;"
-            "if(sessionStorage.getItem('sbVisited'))return;"
-            "var s=document.createElement('style');"
-            "s.textContent='@keyframes sb-bounce{0%,100%{transform:translate(0,0);opacity:1}"
-            "50%{transform:translate(-9px,-9px);opacity:.75}}"
-            "#_sb_hint{display:none;position:fixed;top:68px;left:44px;z-index:99999;"
-            "flex-direction:column;align-items:flex-start;gap:3px;pointer-events:none}"
-            "#_sb_hint ._a{font-size:22px;color:#0088ff;"
-            "animation:sb-bounce 1.1s ease-in-out infinite;line-height:1}"
-            "#_sb_hint ._t{background:#0088ff;color:#fff;padding:3px 9px;"
-            "border-radius:10px;font-size:11px;white-space:nowrap;"
-            "font-family:sans-serif;font-weight:600;"
-            "box-shadow:0 2px 6px rgba(0,136,255,.4)}';"
-            "document.head.appendChild(s);"
-            "var h=document.createElement('div');"
-            "h.id='_sb_hint';"
-            f"h.innerHTML={_hint_inner};"
-            "document.body.appendChild(h);"
-            "function closed(){"
-            "var b=document.querySelector('[data-testid=\"stSidebarCollapsedControl\"]');"
-            "return !!b&&getComputedStyle(b).display!=='none';}"
-            "function dismiss(){"
-            "sessionStorage.setItem('sbVisited','1');"
-            "window._sbShowing=false;"
-            "h.style.display='none';"
-            "if(window._sbTimer){clearTimeout(window._sbTimer);window._sbTimer=null;}"
-            "if(window._sbPoll){clearInterval(window._sbPoll);window._sbPoll=null;}}"
-            "window._sbPoll=setInterval(function(){"
-            "if(sessionStorage.getItem('sbVisited')){clearInterval(window._sbPoll);return;}"
-            "if(window._sbShowing&&!closed())dismiss();},400);"
-            "window._sbTimer=setTimeout(function(){"
-            "if(!sessionStorage.getItem('sbVisited')&&closed()){"
-            "h.style.display='flex';window._sbShowing=true;}},20000);"
-            "})()"
-        )
-        _main_script_json = json.dumps(_main_script)
-        st_components.html(f"""<script>
-(function(){{
-    var p=window.parent;
-    if(!p||p._sbHintInit)return;
-    p._sbHintInit=true;
-    var ps=p.document.createElement('script');
-    ps.textContent={_main_script_json};
-    p.document.head.appendChild(ps);
-    ps.remove();
-}})();
-</script>""", height=0)
 
         # Show documentation (needs no DB) so users aren't stranded on a blank page
         from finance_tracker.web.views.documentation import render as doc_render


### PR DESCRIPTION
## La vraie cause racine (enfin trouvée)

En inspectant le frontend compilé de **Streamlit 1.57** :

```
"data-testid":`stSidebar`,"aria-expanded":!r
```

→ Le testid `stSidebarCollapsedControl` que **toutes** les versions JS précédentes interrogeaient **n'existe plus** dans Streamlit 1.57. Le `querySelector` ne trouvait jamais le bouton, donc la condition « sidebar fermée » était toujours fausse et la flèche ne s'affichait jamais.

En plus :
- `st.html()` ET `st.components.v1.html()` rendent dans une **iframe** → les timers JS meurent à chaque re-render Streamlit.
- `st.components.v1.html` est **déprécié** (supprimé après 2026-06-01) → d'où le warning récurrent.

## Solution propre : CSS pur, zéro JS, zéro iframe

Injecté via `st.markdown(unsafe_allow_html=True)` qui rend **inline dans le document principal** (garde les `<style>`, pas d'iframe, pas de dépréciation) :

- La `<section data-testid="stSidebar">` porte `aria-expanded="false"` quand fermée, `"true"` quand ouverte (vérifié dans le source 1.57).
- Le sélecteur `body:has(section[data-testid="stSidebar"][aria-expanded="false"]) #_sb_hint` n'affiche la flèche **que** sidebar fermée → elle disparaît instantanément à l'ouverture, sans JS.
- `animation-delay: 20s` gère l'attente d'inactivité.
- Keyframe `sb-bounce` pour l'animation de la flèche.

Suppression des imports `json` et `streamlit.components.v1` devenus inutiles.

## Comportement
| Condition | Résultat |
|-----------|----------|
| Pas de DB (branche Python) + sidebar fermée + 20s | Flèche ↖ « Ouvrir le menu » apparaît |
| Sidebar ouverte | Flèche cachée immédiatement |
| DB présente | Jamais affichée (hors branche) |

Note : sans JS/sessionStorage, si l'utilisateur referme la sidebar et attend 20s, l'indice réapparaît — comportement voulu et cohérent.

## Test
- [ ] App sans DB, sidebar fermée → attendre 20s → flèche apparaît
- [ ] Ouvrir sidebar → flèche disparaît
- [ ] Plus aucun warning de dépréciation dans les logs

https://claude.ai/code/session_01VTBKKYLiAQ6mDPdmVhpRAT

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTBKKYLiAQ6mDPdmVhpRAT)_